### PR TITLE
Use hostscope by default for IPAM

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -16,7 +16,6 @@
 {{- $defaultBpfMapDynamicSizeRatio = 0.0025 -}}
 {{- $defaultBpfMasquerade = "true" -}}
 {{- $defaultBpfClockProbe = "true" -}}
-{{- $defaultIPAM = "cluster-pool" -}}
 {{- $defaultSessionAffinity = "true" -}}
 {{- if .Values.global.ipv4.enabled }}
 {{- $defaultOperatorApiServeAddr = "127.0.0.1:9234" -}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Before this PR, the defaul IPAM was using `clusterpool` which uses
undesired cluster CIDRs, for consistency reasons, we are going to rely
on `hostscope` mode which lets kubernetes handle IPAM.


**Which issue(s) this PR fixes**:
Fixes #15 

**Special notes for your reviewer**:
cc @wyb1 and @istvanballok. 


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`hostscope` IPAM is now used by default for Cilium clusters.
```
