### PR TITLE
Update Cilium to v1.8.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,15 +2,15 @@ images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium
-    tag: v1.8.0
+    tag: v1.8.2
   - name: cilium-preflight
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium
-    tag: v1.8.0
+    tag: v1.8.2
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/operator
-    tag: v1.8.0
+    tag: v1.8.2
   - name: cilium-etcd-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium-etcd-operator
@@ -22,8 +22,8 @@ images:
   - name: hubble-ui
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-ui
-    tag: v0.6.0
+    tag: v0.6.1
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
     repository: docker.io/cilium/hubble-relay
-    tag: v1.8.0
+    tag: v1.8.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates Cilium to v1.8.2

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Cilium is now running on v1.8.2. 
```
