### PR TITLE
Add docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ Please find further resources about out project here:
 * [Gardener Extensions Golang library](https://godoc.org/github.com/gardener/gardener/extensions/pkg)
 * [GEP-1 (Gardener Enhancement Proposal) on extensibility](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md)
 * [Extensibility API documentation](https://github.com/gardener/gardener/tree/master/docs/extensions)
+* [Docs for `cilium` user](https://docs.cilium.io/)


### PR DESCRIPTION
Add docs link https://docs.cilium.io to README

**What this PR does / why we need it**:

The docs page is useful and I think it should be seen on README

**Which issue(s) this PR fixes**:
No

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
- category:       improvement
- target_group:   user
```
