### PR TITLE
Update cilium to v1.8.5 and update missing clusterrole permissions.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,15 +2,15 @@ images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium
-    tag: v1.8.4
+    tag: v1.8.5
   - name: cilium-preflight
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium
-    tag: v1.8.4
+    tag: v1.8.5
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/operator
-    tag: v1.8.4
+    tag: v1.8.5
   - name: cilium-etcd-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium-etcd-operator
@@ -26,4 +26,4 @@ images:
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
     repository: docker.io/cilium/hubble-relay
-    tag: v1.8.4
+    tag: v1.8.5

--- a/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
@@ -34,6 +34,16 @@ rules:
   - ""
   resources:
   - pods
+  - pods/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get
@@ -70,12 +80,19 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+  - ciliumnetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies
   - ciliumclusterwidenetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumendpoints
   - ciliumendpoints/status
+  - ciliumendpoints/finalizers
   - ciliumnodes
   - ciliumnodes/status
+  - ciliumnodes/finalizers
   - ciliumidentities
+# deprecated remove in v1.9
+  - ciliumidentities/status
+  - ciliumidentities/finalizers
   verbs:
   - '*'

--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -464,16 +464,6 @@ data:
 {{- if and .Values.global.sockops .Values.global.sockops.enabled }}
   sockops-enable: {{ .Values.global.sockops.enabled | quote }}
 {{- end }}
-{{- if and .Values.global.k8s .Values.global.k8s.requireIPv4PodCIDR }}
-  k8s-require-ipv4-pod-cidr: {{ .Values.global.k8s.requireIPv4PodCIDR | quote }}
-{{- else }}
-{{- if eq $ipam "cluster-pool" }}
-  k8s-require-ipv4-pod-cidr: {{ .Values.global.ipv4.enabled | quote}}
-{{- end }}
-{{- end }}
-{{- if eq $ipam "cluster-pool" }}
-  k8s-require-ipv6-pod-cidr: {{ .Values.global.ipv6.enabled | quote}}
-{{- end }}
 {{- if and .Values.global.endpointRoutes .Values.global.endpointRoutes.enabled }}
   enable-endpoint-routes: {{ .Values.global.endpointRoutes.enabled | quote }}
 {{- end }}
@@ -501,7 +491,7 @@ data:
   enable-well-known-identities: "false"
 {{- end }}
   enable-remote-node-identity: {{ .Values.global.remoteNodeIdentity | quote }}
-
+  enable-api-rate-limit: {{ .Values.global.apiRateLimit | quote }}
 {{- if hasKey .Values "synchronizeK8sNodes" }}
   synchronize-k8s-nodes: {{ .Values.synchronizeK8sNodes | quote }}
 {{- end }}

--- a/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
@@ -43,14 +43,19 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
+  - ciliumnetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies
   - ciliumclusterwidenetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumendpoints
   - ciliumendpoints/status
+  - ciliumendpoints/finalizers
   - ciliumnodes
   - ciliumnodes/status
+  - ciliumnodes/finalizers
   - ciliumidentities
   - ciliumidentities/status
+  - ciliumidentities/finalizers
   verbs:
   - '*'
 - apiGroups:
@@ -61,3 +66,20 @@ rules:
     - get
     - list
     - watch
+# For cilium-operator running in HA mode.
+#
+# Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
+# between mulitple running instances.
+# The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
+# common and fewer objects in the cluster watch "all Leases".
+# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.
+# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure
+# that we only authorize access to leases resources in supported K8s versions.
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update

--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
   name: cilium-operator
   namespace: {{ .Release.Namespace }}
 spec:
+  # We support HA mode only for Kubernetes version > 1.14
+  # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
+  # for more details.
   replicas: 1
   selector:
     matchLabels:
@@ -28,6 +31,18 @@ spec:
         io.cilium/app: operator
         name: cilium-operator
     spec:
+      # In HA mode, cilium-operator pods must not be scheduled on the same
+      # node as they will clash with each other.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: io.cilium/app
+                operator: In
+                values:
+                - operator
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - args:
         - --config-dir=/tmp/cilium/config-map
@@ -107,6 +122,8 @@ spec:
       priorityClassName: system-cluster-critical
       serviceAccount: cilium-operator
       serviceAccountName: cilium-operator
+      tolerations:
+      - operator: Exists
       volumes:
         # To read the configuration from the config map
       - configMap:

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -321,12 +321,6 @@ global:
     # enabled enables installation of socket level functionality.
     enabled: false
 
-  # k8s is the Kubernetes specific configuration
-  k8s:
-    # requireIPv4PodCIDR enables waiting for Kubernetes to provide the PodCIDR
-    # range via the Kubernetes node resource
-    requireIPv4PodCIDR: false
-
   # ENI mode configures the options required to run with ENI
   eni: false
 
@@ -370,6 +364,8 @@ global:
 
   # remoteNodeIdentity enables use of the remote node identity
   remoteNodeIdentity: true
+
+  apiRateLimit: false
 
   synchronizeK8sNodes: true
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update cilium to `v1.8.5` and update missing clusterrole permissions.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update cilium to `v1.8.5` and update missing clusterrole permissions.
```
