### PR TITLE
Disable cache for Secrets and ConfigMaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test:
 test-cov:
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test-cover.sh ./cmd/... ./pkg/...
 
-.PHONY: test-clean
+.PHONY: test-cov-clean
 test-clean:
 	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/test-cover-clean.sh
 
@@ -113,4 +113,4 @@ test-clean:
 verify: check format test
 
 .PHONY: verify-extended
-verify-extended: install-requirements check-generate check format test-cov test-clean
+verify-extended: install-requirements check-generate check format test-cov test-cov-clean

--- a/cmd/gardener-extension-networking-cilium/app/app.go
+++ b/cmd/gardener-extension-networking-cilium/app/app.go
@@ -28,7 +28,9 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	"github.com/gardener/gardener/pkg/client/kubernetes/utils"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -75,7 +77,13 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 			util.ApplyClientConnectionConfigurationToRESTConfig(configFileOpts.Completed().Config.ClientConnection, restOpts.Completed().Config)
 
-			mgr, err := manager.New(restOpts.Completed().Config, mgrOpts.Completed().Options())
+			completedMgrOpts := mgrOpts.Completed().Options()
+			completedMgrOpts.NewClient = utils.NewClientFuncWithDisabledCacheFor(
+				&corev1.Secret{},    // applied for ManagedResources
+				&corev1.ConfigMap{}, // applied for monitoring config
+			)
+
+			mgr, err := manager.New(restOpts.Completed().Config, completedMgrOpts)
 			if err != nil {
 				controllercmd.LogErrAndExit(err, "Could not instantiate manager")
 			}


### PR DESCRIPTION
/area cost
/kind enhancement

Ref gardener/gardener-extension-networking-calico#55

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The cache for Secrets and ConfigMaps is now disabled to decrease the extension controller's memory footprint
```
