### PR TITLE
Update cilium to v.1.9.4 and switch ipam mode to cluster-pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ TODO
 
 # Packr generated files
 *-packr.go
+
+# GitGuardian
+.cache_ggshield

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,16 +1,16 @@
 images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
-    repository: docker.io/cilium/cilium
-    tag: v1.8.5
+    repository: quay.io/cilium/cilium
+    tag: v1.9.4
   - name: cilium-preflight
     sourceRepository: github.com/cilium/cilium
-    repository: docker.io/cilium/cilium
-    tag: v1.8.5
+    repository: quay.io/cilium/cilium
+    tag: v1.9.4
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
-    repository: docker.io/cilium/operator
-    tag: v1.8.5
+    repository: quay.io/cilium/operator
+    tag: v1.9.4
   - name: cilium-etcd-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium-etcd-operator
@@ -22,8 +22,20 @@ images:
   - name: hubble-ui
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-ui
-    tag: v0.6.1
+    tag: v0.7.3
+  - name: hubble-ui-backend
+    sourceRepository: github.com/cilium/hubble-ui-backend
+    repository: quay.io/cilium/hubble-ui-backend
+    tag: v0.7.3
+  - name: envoy
+    sourceRepository: github.com/envoyproxy/envoy
+    repository: docker.io/envoyproxy/envoy
+    tag: v1.14.5
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
-    repository: docker.io/cilium/hubble-relay
-    tag: v1.8.5
+    repository: quay.io/cilium/hubble-relay
+    tag: v1.9.4
+  - name: certgen
+    sourceRepository: github.com/cilium/certgen
+    repository: quay.io/cilium/certgen
+    tag: v0.1.3

--- a/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
@@ -62,11 +62,15 @@ rules:
   resources:
   - customresourcedefinitions
   verbs:
+  # Deprecated for removal in v1.10
   - create
-  - get
   - list
   - watch
   - update
+  # This is used when validating policies in preflight. This will need to stay
+  # until we figure out how to avoid "get" inside the preflight, and then
+  # should be removed ideally.
+  - get
 {{- if eq "k8s" .Values.global.tls.secretsBackend }}
 - apiGroups:
   - ""
@@ -91,8 +95,9 @@ rules:
   - ciliumnodes/status
   - ciliumnodes/finalizers
   - ciliumidentities
-# deprecated remove in v1.9
-  - ciliumidentities/status
   - ciliumidentities/finalizers
+  - ciliumlocalredirectpolicies
+  - ciliumlocalredirectpolicies/status
+  - ciliumlocalredirectpolicies/finalizers
   verbs:
   - '*'

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -200,6 +200,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /var/lib/cilium/tls/hubble
+          name: hubble-tls
+          readOnly: true
 {{- if .Values.global.encryption.enabled }}
         - mountPath: {{ .Values.global.encryption.mountPath }}
           name: cilium-ipsec-secrets
@@ -364,6 +367,23 @@ spec:
       - configMap:
           name: cilium-config
         name: cilium-config-path
+      - name: hubble-tls
+        projected:
+          sources:
+          - secret:
+              name: hubble-server-certs
+              items:
+                - key: tls.crt
+                  path: server.crt
+                - key: tls.key
+                  path: server.key
+              optional: true
+          - configMap:
+              name: hubble-ca-cert
+              items:
+                - key: ca.crt
+                  path: client-ca.crt
+              optional: true
 {{- if and .Values.global.ipMasqAgent .Values.global.ipMasqAgent.enabled }}
       - configMap:
           name: ip-masq-agent

--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -3,7 +3,6 @@
 {{- $defaultBpfMapDynamicSizeRatio := 0.0 -}}
 {{- $defaultBpfMasquerade := "false" -}}
 {{- $defaultBpfClockProbe := "false" -}}
-{{- $defaultIPAM := "hostscope" -}}
 {{- $defaultSessionAffinity := "false" -}}
 {{- $defaultOperatorApiServeAddr := "localhost:9234" -}}
 {{- $defaultBpfCtTcpMax := 524288 -}}
@@ -26,7 +25,6 @@
 {{- $defaultBpfCtAnyMax = 0 -}}
 {{- end -}}
 
-{{- $ipam := (coalesce .Values.ipam $defaultIPAM) -}}
 {{- $bpfCtTcpMax := (coalesce .Values.global.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.global.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}
 
@@ -98,6 +96,10 @@ data:
 
   # If you want to run cilium in debug mode change this value to true
   debug: {{ .Values.global.debug.enabled | quote }}
+  # The agent can be put into the following three policy enforcement modes
+  # default, always and never.
+  # https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
+  enable-policy: "{{ .Values.global.agent.policyMode }}"
 
 {{- if .Values.global.debug.verbose }}
   debug-verbose: "{{ .Values.global.debug.verbose }}"
@@ -220,13 +222,16 @@ data:
   # BPF neighbor table.
   bpf-neigh-global-max: "{{ .Values.global.bpf.neighMax }}"
 {{- end }}
-
 {{- if .Values.global.bpf.policyMapMax }}
   # bpf-policy-map-max specified the maximum number of entries in endpoint
   # policy map (per endpoint)
   bpf-policy-map-max: "{{ .Values.global.bpf.policyMapMax }}"
 {{- end }}
-
+{{- if .Values.global.bpf.lbMapMax }}
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+  bpf-lb-map-max: "{{ .Values.global.bpf.lbMapMax }}"
+{{- end }}
 {{- if hasKey .Values "bpfMapDynamicSizeRatio" }}
   bpf-map-dynamic-size-ratio: {{ .Values.bpfMapDynamicSizeRatio | quote }}
 {{- else if ne $defaultBpfMapDynamicSizeRatio 0.0 }}
@@ -245,9 +250,8 @@ data:
   #
   # If this value is modified, then during the next Cilium startup the restore
   # of existing endpoints and tracking of ongoing connections may be disrupted.
-  # This may lead to policy drops or a change in loadbalancing decisions for a
-  # connection for some time. Endpoints may need to be recreated to restore
-  # connectivity.
+  # As a result, reply packets may be dropped and the load-balancing decisions
+  # for established connections may change.
   #
   # If this option is set to "false" during an upgrade from 1.3 or earlier to
   # 1.4 or later, then it may cause one-time disruptions during the upgrade.
@@ -301,7 +305,6 @@ data:
 {{- end }}
 
 {{- if .Values.global.l7Proxy }}
-
   # Enables L7 proxy for L7 policy enforcement and visibility
   enable-l7-proxy: {{ .Values.global.l7Proxy.enabled | quote }}
 {{- end }}
@@ -389,6 +392,12 @@ data:
   iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
 {{- end }}
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
+{{- if .Values.global.bandwidthManager.enabled }}
+  enable-bandwidth-manager: {{ .Values.global.bandwidthManager.enabled | quote }}
+{{- end }}
+{{- if .Values.global.localRedirectPolicy.enabled }}
+  enable-local-redirect-policy: {{ .Values.global.localRedirectPolicy.enabled | quote }}
+{{- end }}
 {{- if .Values.global.nativeRoutingCIDR }}
   native-routing-cidr: {{ .Values.global.nativeRoutingCIDR }}
 {{- end }}
@@ -405,6 +414,9 @@ data:
 
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
+{{- end}}
+{{- if .Values.global.kubeProxyReplacementHealthzBindAddress }}
+kube-proxy-replacement-healthz-bind-address: "{{ .Values.global.kubeProxyReplacementHealthzBindAddress }}"
 {{- end}}
 {{- if .Values.global.hostServices }}
 {{- if .Values.global.hostServices.enabled }}
@@ -531,22 +543,25 @@ data:
   # An additional address for Hubble server to listen to (e.g. ":4244").
   hubble-listen-address: {{ .Values.global.hubble.listenAddress | quote }}
 {{- end }}
+  hubble-disable-tls: {{ (not .Values.global.hubble.tls.enabled) | quote }}
+{{- if .Values.global.hubble.tls.enabled }}
+  hubble-tls-auto-enabled: {{ .Values.global.hubble.tls.auto.enabled | quote }}
+  hubble-tls-cert-file: {{ .Values.global.hubble.tls.certFile | quote }}
+  hubble-tls-key-file: {{ .Values.global.hubble.tls.keyFile | quote }}
+  hubble-tls-client-ca-files: {{ .Values.global.hubble.tls.clientCAFiles | quote }}
+{{- end }}
 {{- if .Values.disableIptablesFeederRules }}
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: {{ .Values.disableIptablesFeederRules | join " " | quote }}
 {{- end }}
-{{- if ne $ipam "hostscope" }}
-  ipam: {{ $ipam | quote }}
-{{- end }}
-{{- if eq $ipam "cluster-pool" }}
+  ipam: "cluster-pool"
 {{- if .Values.global.ipv4.enabled }}
-  cluster-pool-ipv4-cidr: {{ .Values.global.ipam.operator.clusterPoolIPv4PodCIDR | quote }}
-  cluster-pool-ipv4-mask-size: {{ .Values.global.ipam.operator.clusterPoolIPv4MaskSize | quote  }}
+  cluster-pool-ipv4-cidr: {{ .Values.global.podCIDR | quote }}
+  cluster-pool-ipv4-mask-size: {{ .Values.global.ipam.operator.clusterPoolIPv4MaskSize | quote }}
 {{- end }}
 {{- if .Values.global.ipv6.enabled }}
   cluster-pool-ipv6-cidr: {{ .Values.global.ipam.operator.clusterPoolIPv6PodCIDR | quote }}
   cluster-pool-ipv6-mask-size: {{ .Values.global.ipam.operator.clusterPoolIPv6MaskSize | quote }}
-{{- end }}
 {{- end }}
 
 {{- if hasKey .Values "enableCnpStatusUpdates" }}

--- a/charts/internal/cilium/charts/hubble-relay/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/clusterrole.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: hubble-relay
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - componentstatuses
+      - endpoints
+      - namespaces
+      - nodes
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: hubble-generate-certs
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - hubble-server-certs
+      - hubble-relay-client-certs
+      - hubble-relay-server-certs
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - hubble-ca-cert
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - hubble-ca-secret
+    verbs:
+      - get

--- a/charts/internal/cilium/charts/hubble-relay/templates/clusterrolebinding.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/clusterrolebinding.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: hubble-relay
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble-relay
+subjects:
+- kind: ServiceAccount
+  name: hubble-relay
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: hubble-generate-certs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hubble-generate-certs
+subjects:
+- kind: ServiceAccount
+  name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}

--- a/charts/internal/cilium/charts/hubble-relay/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/configmap.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-relay-config
+  namespace: {{ .Release.Namespace }}
+data:
+  config.yaml: |
+    peer-service: unix://{{ .Values.global.hubble.socketPath }}
+    listen-address: {{ .Values.listenHost }}:{{ .Values.listenPort }}
+    dial-timeout: {{ .Values.dialTimeout }}
+    retry-timeout: {{ .Values.retryTimeout }}
+    sort-buffer-len-max: {{ .Values.sortBufferLenMax }}
+    sort-buffer-drain-timeout: {{ .Values.sortBufferDrainTimeout }}
+    tls-client-cert-file: {{ .Values.tlsClientCertFile }}
+    tls-client-key-file: {{ .Values.tlsClientKeyFile }}
+    tls-hubble-server-ca-files: {{ .Values.tlsHubbleServerCAFiles }}
+    disable-server-tls: {{ .Values.disableServerTls | quote }}

--- a/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
@@ -1,0 +1,48 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble-generate-certs
+    gardener.cloud/role: system-component
+spec:
+  schedule: "0 0 1 */4 *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            k8s-app: hubble-generate-certs
+        spec:
+          serviceAccount: hubble-generate-certs
+          serviceAccountName: hubble-generate-certs
+          containers:
+            - name: certgen
+              image: {{ index .Values.global.images "certgen" }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - "/usr/bin/cilium-certgen"
+              # Because this is executed as a job, we pass the values as command
+              # line args instead of via config map. This allows users to inspect
+              # the values used in past runs by inspecting the completed pod.
+              args:
+                - "--cilium-namespace=kube-system"
+                - "--hubble-ca-reuse-secret=true"
+                - "--hubble-ca-secret-name=hubble-ca-secret"
+                - "--hubble-ca-generate=true"
+                - "--hubble-ca-validity-duration=94608000s"
+                - "--hubble-ca-config-map-create=true"
+                - "--hubble-ca-config-map-name=hubble-ca-cert"
+                - "--hubble-server-cert-generate=true"
+                - "--hubble-server-cert-common-name=*.{{ .Values.global.cluster.name }}.hubble-grpc.cilium.io"
+                - "--hubble-server-cert-validity-duration=94608000s"
+                - "--hubble-server-cert-secret-name=hubble-server-certs"
+                - "--hubble-relay-client-cert-generate=true"
+                - "--hubble-relay-client-cert-validity-duration=94608000s"
+                - "--hubble-relay-client-cert-secret-name=hubble-relay-client-certs"
+                - "--hubble-relay-server-cert-generate=false"
+          hostNetwork: true
+          restartPolicy: OnFailure
+      ttlSecondsAfterFinished: 1800

--- a/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -33,8 +33,6 @@ spec:
           - "hubble-relay"
           args:
           - "serve"
-          - "--peer-service=unix://{{ .Values.global.hubble.socketPath }}"
-          - "--listen-address={{ .Values.listenHost }}:{{ .Values.listenPort }}"
           ports:
           - name: grpc
             containerPort: {{ .Values.listenPort }}
@@ -52,7 +50,14 @@ spec:
           - mountPath: {{ dir .Values.global.hubble.socketPath }}
             name: hubble-sock-dir
             readOnly: true
+          - mountPath: /etc/hubble-relay
+            name: config
+            readOnly: true
+          - mountPath: /var/lib/hubble-relay/tls
+            name: tls
+            readOnly: true
       restartPolicy: Always
+      serviceAccountName: hubble-relay
       terminationGracePeriodSeconds: 0
       tolerations:
       - operator: Exists
@@ -61,3 +66,25 @@ spec:
           path: {{ dir .Values.global.hubble.socketPath }}
           type: Directory
         name: hubble-sock-dir
+      - configMap:
+          name: hubble-relay-config
+          items:
+          - key: config.yaml
+            path: config.yaml
+        name: config
+      - projected:
+          sources:
+          - secret:
+              name: hubble-relay-client-certs
+              items:
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+          - configMap:
+              name: hubble-ca-cert
+              items:
+                - key: ca.crt
+                  path: hubble-server-ca.crt
+        name: tls
+

--- a/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble-generate-certs
+    gardener.cloud/role: system-component
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: hubble-generate-certs
+    spec:
+      serviceAccount: hubble-generate-certs
+      serviceAccountName: hubble-generate-certs
+      containers:
+        - name: certgen
+          image: {{ index .Values.global.images "certgen" }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/usr/bin/cilium-certgen"
+          # Because this is executed as a job, we pass the values as command
+          # line args instead of via config map. This allows users to inspect
+          # the values used in past runs by inspecting the completed pod.
+          args:
+            - "--cilium-namespace=kube-system"
+            - "--hubble-ca-reuse-secret=true"
+            - "--hubble-ca-secret-name=hubble-ca-secret"
+            - "--hubble-ca-generate=true"
+            - "--hubble-ca-validity-duration=94608000s"
+            - "--hubble-ca-config-map-create=true"
+            - "--hubble-ca-config-map-name=hubble-ca-cert"
+            - "--hubble-server-cert-generate=true"
+            - "--hubble-server-cert-common-name=*.{{ .Values.global.cluster.name }}.hubble-grpc.cilium.io"
+            - "--hubble-server-cert-validity-duration=94608000s"
+            - "--hubble-server-cert-secret-name=hubble-server-certs"
+            - "--hubble-relay-client-cert-generate=true"
+            - "--hubble-relay-client-cert-validity-duration=94608000s"
+            - "--hubble-relay-client-cert-secret-name=hubble-relay-client-certs"
+            - "--hubble-relay-server-cert-generate=false"
+      hostNetwork: true
+      restartPolicy: OnFailure
+  ttlSecondsAfterFinished: 1800

--- a/charts/internal/cilium/charts/hubble-relay/templates/serviceaccount.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-relay
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}

--- a/charts/internal/cilium/charts/hubble-relay/values.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/values.yaml
@@ -16,5 +16,19 @@ dialTimeout: ~
 # Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
 retryTimeout: ~
 
+# Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100).
+sortBufferLenMax:
+
+# When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s").
+sortBufferDrainTimeout:
+
+tlsClientCertFile: /var/lib/hubble-relay/tls/client.crt
+
+tlsClientKeyFile: /var/lib/hubble-relay/tls/client.key
+
+tlsHubbleServerCAFiles: /var/lib/hubble-relay/tls/hubble-server-ca.crt
+
+disableServerTls: true
+
 # Port to use for the k8s service backed by hubble-relay pods.
 servicePort: 80

--- a/charts/internal/cilium/charts/hubble-ui/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: hubble-ui 
+  name: hubble-ui
 rules:
   - apiGroups:
       - networking.k8s.io

--- a/charts/internal/cilium/charts/hubble-ui/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/configmap.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hubble-ui-envoy
+  namespace: {{ .Release.Namespace }}
+data:
+  envoy.yaml: |
+    static_resources:
+      listeners:
+        - name: listener_hubble_ui
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 12000
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  config:
+                    codec_type: auto
+                    stat_prefix: ingress_http
+                    route_config:
+                      name: local_route
+                      virtual_hosts:
+                        - name: local_service
+                          domains: ['*']
+                          routes:
+                            - match:
+                                prefix: '/api/'
+                              route:
+                                cluster: backend
+                                max_grpc_timeout: 0s
+                                prefix_rewrite: '/'
+                            - match:
+                                prefix: '/'
+                              route:
+                                cluster: frontend
+                          cors:
+                            allow_origin_string_match:
+                              - prefix: '*'
+                            allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                            allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                            max_age: '1728000'
+                            expose_headers: grpc-status,grpc-message
+                    http_filters:
+                      - name: envoy.filters.http.grpc_web
+                      - name: envoy.filters.http.cors
+                      - name: envoy.filters.http.router
+      clusters:
+        - name: frontend
+          connect_timeout: 0.25s
+          type: strict_dns
+          lb_policy: round_robin
+          hosts:
+            - socket_address:
+                address: 127.0.0.1
+                port_value: 8080
+        - name: backend
+          connect_timeout: 0.25s
+          type: logical_dns
+          lb_policy: round_robin
+          http2_protocol_options: {}
+          hosts:
+            - socket_address:
+                address: 127.0.0.1
+                port_value: 8090

--- a/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -4,6 +4,8 @@ kind: Deployment
 metadata:
   namespace: {{ .Release.Namespace }}
   name: hubble-ui
+  labels:
+    k8s-app: hubble-ui
 spec:
   replicas: {{ .Values.replicas }}
   selector:
@@ -21,20 +23,40 @@ spec:
       serviceAccountName: hubble-ui
       serviceAccount: hubble-ui
       containers:
-        - name: hubble-ui
+        - name: frontend
           image: {{ index .Values.global.images "hubble-ui" }}
           imagePullPolicy: {{ .Values.global.pullPolicy }}
+          ports:
+            - containerPort: 8080
+              name: http
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - name: backend
+          image: {{ index .Values.global.images "hubble-ui-backend" }}
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
           env:
-            - name: NODE_ENV
-              value: "production"
-            - name: LOG_LEVEL
-              value: "info"
-            - name: HUBBLE
-              value: "true"
-            - name: HUBBLE_SERVICE
-              value: "hubble-relay"
-            - name: HUBBLE_PORT
-              value: "80"
+            - name: EVENTS_SERVER_PORT
+              value: "8090"
+            - name: FLOWS_API_ADDR
+              value: "hubble-relay:80"
+          ports:
+            - containerPort: 8090
+              name: grpc
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 64Mi
+        - name: proxy
+          image: {{ index .Values.global.images "envoy" }}
+          imagePullPolicy: {{ .Values.global.pullPolicy }}
           ports:
             - containerPort: 12000
               name: http
@@ -45,3 +67,19 @@ spec:
             requests:
               cpu: 100m
               memory: 64Mi
+          command: ["envoy"]
+          args:
+            [
+              "-c",
+              "/etc/envoy.yaml",
+              "-l",
+              "info"
+            ]
+          volumeMounts:
+            - name: hubble-ui-envoy-yaml
+              mountPath: /etc/envoy.yaml
+              subPath: envoy.yaml
+      volumes:
+        - name: hubble-ui-envoy-yaml
+          configMap:
+            name: hubble-ui-envoy

--- a/charts/internal/cilium/charts/hubble-ui/templates/svc.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/svc.yaml
@@ -4,6 +4,8 @@ kind: Service
 metadata:
   namespace: {{ .Release.Namespace }}
   name: hubble-ui
+  labels:
+    k8s-app: hubble-ui
 spec:
   selector:
     k8s-app: hubble-ui

--- a/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
@@ -56,6 +56,9 @@ rules:
   - ciliumidentities
   - ciliumidentities/status
   - ciliumidentities/finalizers
+  - ciliumlocalredirectpolicies
+  - ciliumlocalredirectpolicies/status
+  - ciliumlocalredirectpolicies/finalizers
   verbs:
   - '*'
 - apiGroups:
@@ -63,9 +66,11 @@ rules:
   resources:
     - customresourcedefinitions
   verbs:
-    - get
-    - list
-    - watch
+  - create
+  - get
+  - list
+  - update
+  - watch
 # For cilium-operator running in HA mode.
 #
 # Cilium operator running in HA mode requires the use of ResourceLock for Leader Election

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -24,6 +24,7 @@ requirements:
 
 # global groups all configuration options that have effect on all sub-charts
 global:
+  podCIDR: ""
   # pullPolicy is the container image pull policy
   pullPolicy: IfNotPresent
 
@@ -41,6 +42,14 @@ global:
       - icmp
       - http
       port: 9091
+    tls:
+      enabled: true
+      auto:
+        enabled: true
+      certFile: /var/lib/cilium/tls/hubble/server.crt
+      keyFile: /var/lib/cilium/tls/hubble/server.key
+      clientCAFiles: /var/lib/cilium/tls/hubble/client-ca.crt
+
 
   # etcd is the etcd configuration
   etcd:
@@ -66,6 +75,8 @@ global:
   #  kvstore: Key-value store backend (better scalability)
   identityAllocationMode: crd
 
+  endpointGCInterval: 5m0s
+
   # ipv4 is the IPv4 addressing configuration
   ipv4:
     enabled: true
@@ -89,6 +100,10 @@ global:
     sleepAfterInit: false
     # Keep the deprecated probes when deploying Cilium DaemonSet
     keepDeprecatedProbes: false
+    # The agent can be put into the following three policy enforcement modes
+    # default, always and never.
+    # https://docs.cilium.io/en/latest/policy/intro/#policy-enforcement-modes
+    policyMode: default
 
   # prometheus enables
   prometheus:
@@ -126,6 +141,11 @@ global:
   # autoDirectNodeRoutes enables installation of PodCIDR routes between worker
   # nodes if worker nodes share a common L2 network segment.
   autoDirectNodeRoutes: false
+
+  bandwidthManager:
+    enabled: false
+  localRedirectPolicy:
+    enabled: false
 
   # endpointRoutes enables use of per endpoint routes instead of routing vis
   # the cilium_host interface
@@ -178,8 +198,8 @@ global:
     # name is the human readable name of the cluster when setting up
     # clustermesh
     name: default
-
-    # id is a 8 bits unique cluster identifier when setting up clustermesh
+    # Unique ID of the cluster. Must be unique across all conneted clusters and
+    # in the range of 1 and 255. Only relevant when building a mesh of clusters.
     #id: "1"
 
   # tunnel is the encapsulation configuration for communication between nodes
@@ -235,6 +255,14 @@ global:
     # first time
     monitorFlags: "all"
 
+  # bpf-policy-map-max specifies the maximum number of entries in endpoint
+  # policy map (per endpoint)
+    policyMapMax: "16384"
+
+  # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
+  # backend and affinity maps.
+    lbMapMax: "65536"
+
   # encryption is the encryption specific configuration
   encryption:
     # enabled enables encryption
@@ -259,6 +287,8 @@ global:
 
   # kubeProxyReplacement enables kube-proxy replacement in Cilium BPF datapath
   kubeProxyReplacement: "probe"
+  # The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable
+  kubeProxyReplacementHealthzBindAddress: ""
 
   # hostServices is the configuration for ClusterIP service handling in host namespace
   hostServices:
@@ -377,6 +407,10 @@ global:
     # Regular expression matching compatible Istio sidecar istio-proxy
     # container image names
     sidecarImageRegex: "cilium/istio_proxy"
+  
+  # Enables L7 proxy for L7 policy enforcement and visibility
+  l7proxy:
+    enabled: true
 
   ipam:
     operator:
@@ -412,4 +446,9 @@ global:
     cilium-preflight: "image-repository:image-tag"
 
     hubble: "image-repository:image-tag"
-    hubble-ui:  "image-repository:image-tag"
+    hubble-relay: "image-repository:image-tag"
+    hubble-ui: "image-repository:image-tag"
+    hubble-ui-backend: "image-repository:image-tag"
+    certgen: "image-repository:image-tag"
+    envoy: "image-repository:image-tag"
+

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -9,7 +9,7 @@ In this document we are describing how this configuration looks like for Cilium 
 Hubble is a fully distributed networking and security observability platform build on top of Cilium and BPF. It is optional and is deployed to the cluster when enabled in the `NetworkConfig`.
 If the dashboard is not externally exposed
 ```
-kubectl port-forward -n kube-system deployment/hubble-ui 8080:12000
+kubectl port-forward -n kube-system deployment/hubble-ui 12000
 ```
 can be used to acess it locally.
 

--- a/pkg/charts/config.go
+++ b/pkg/charts/config.go
@@ -30,6 +30,7 @@ type globalConfig struct {
 	K8sServiceHost         string                                  `json:"k8sServiceHost"`
 	K8sServicePort         int32                                   `json:"k8sServicePort"`
 	NodePort               nodePort                                `json:"nodePort"`
+	PodCIDR                string                                  `json:"podCIDR"`
 }
 
 // etcd related configuration for cilium

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -17,6 +17,7 @@ package charts
 import (
 	ciliumv1alpha1 "github.com/gardener/gardener-extension-networking-cilium/pkg/apis/cilium/v1alpha1"
 	"github.com/gardener/gardener-extension-networking-cilium/pkg/cilium"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/gardener/gardener/pkg/chartrenderer"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,8 +27,8 @@ import (
 const CiliumConfigKey = "config.yaml"
 
 // RenderCiliumChart renders the cilium chart with the given values.
-func RenderCiliumChart(renderer chartrenderer.Interface, config *ciliumv1alpha1.NetworkConfig) ([]byte, error) {
-	values, err := ComputeCiliumChartValues(config)
+func RenderCiliumChart(renderer chartrenderer.Interface, config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network) ([]byte, error) {
+	values, err := ComputeCiliumChartValues(config, network)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cilium/types.go
+++ b/pkg/cilium/types.go
@@ -35,6 +35,14 @@ const (
 	HubbleRelayImageName = "hubble-relay"
 	// HubbleUIImageName defines the UI image name.
 	HubbleUIImageName = "hubble-ui"
+	// HubbleUIBackendImageName defines the UI Backend image name.
+	HubbleUIBackendImageName = "hubble-ui-backend"
+
+	// CertGenImageName defines certificate generation image name.
+	CertGenImageName = "certgen"
+
+	// EnvoyImageName defines the envoy image name.
+	EnvoyImageName = "envoy"
 
 	// MonitoringChartName
 	MonitoringName = "cilium-monitoring-config"

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -91,7 +91,7 @@ func (a *actuator) Reconcile(ctx context.Context, network *extensionsv1alpha1.Ne
 		return errors.Wrapf(err, "could not create chart renderer for shoot '%s'", network.Namespace)
 	}
 
-	ciliumChart, err := charts.RenderCiliumChart(chartRenderer, networkConfig)
+	ciliumChart, err := charts.RenderCiliumChart(chartRenderer, networkConfig, network)
 	if err != nil {
 		return err
 	}

--- a/pkg/imagevector/image_finders.go
+++ b/pkg/imagevector/image_finders.go
@@ -45,3 +45,18 @@ func CiliumHubbleRelayImage() string {
 func CiliumHubbleUIImage() string {
 	return findImage(cilium.HubbleUIImageName)
 }
+
+// CiliumHubbleUIBackendImage returns the Cilium Hubble UI Backend image.
+func CiliumHubbleUIBackendImage() string {
+	return findImage(cilium.HubbleUIBackendImageName)
+}
+
+// CiliumCertGenImage returns the Cilium Cert Gen image.
+func CiliumCertGenImage() string {
+	return findImage(cilium.CertGenImageName)
+}
+
+// CiliumEnvoyImage returns the Envoy image.
+func CiliumEnvoyImage() string {
+	return findImage(cilium.EnvoyImageName)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/priority normal

**What this PR does / why we need it**:
This PR updates Cilium to `v.1.9.4`. The ipam mode is switched from legacy `hostscope` mode which is removed to `cluter-pool` ipam mode.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Cilium is updated to `v.1.9.4`. The ipam mode is switched from legacy `hostscope` mode which is removed to `cluter-pool` ipam mode.  
```
