### PR TITLE
Update cilium to v1.10.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,15 +2,15 @@ images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.9.6
+    tag: v1.10.1
   - name: cilium-preflight
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.9.6
+    tag: v1.10.1
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/operator
-    tag: v1.9.6
+    tag: v1.10.1
   - name: cilium-etcd-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium-etcd-operator
@@ -22,20 +22,20 @@ images:
   - name: hubble-ui
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-ui
-    tag: v0.7.3
+    tag: v0.7.9
   - name: hubble-ui-backend
     sourceRepository: github.com/cilium/hubble-ui-backend
     repository: quay.io/cilium/hubble-ui-backend
-    tag: v0.7.3
+    tag: v0.7.9
   - name: envoy
     sourceRepository: github.com/envoyproxy/envoy
     repository: docker.io/envoyproxy/envoy
-    tag: v1.14.5
+    tag: v1.18.2
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-relay
-    tag: v1.9.6
+    tag: v1.10.1
   - name: certgen
     sourceRepository: github.com/cilium/certgen
     repository: quay.io/cilium/certgen
-    tag: v0.1.3
+    tag: v0.1.4

--- a/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
@@ -98,6 +98,6 @@ rules:
   - ciliumidentities/finalizers
   - ciliumlocalredirectpolicies
   - ciliumlocalredirectpolicies/status
-  - ciliumlocalredirectpolicies/finalizers
+  - ciliumegressnatpolicies
   verbs:
   - '*'

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -56,6 +56,8 @@ spec:
           # The initial delay for the liveness probe is intentionally large to
           # avoid an endless kill & restart cycle if in the event that the initial
           # bootstrapping takes longer than expected.
+          # Starting from Kubernetes 1.20, we are using startupProbe instead
+          # of this field.
           initialDelaySeconds: 120
           periodSeconds: 30
           successThreshold: 1
@@ -94,18 +96,6 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        - name: CILIUM_FLANNEL_MASTER_DEVICE
-          valueFrom:
-            configMapKeyRef:
-              key: flannel-master-device
-              name: cilium-config
-              optional: true
-        - name: CILIUM_FLANNEL_UNINSTALL_ON_EXIT
-          valueFrom:
-            configMapKeyRef:
-              key: flannel-uninstall-on-exit
-              name: cilium-config
-              optional: true
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
         - name: CILIUM_CNI_CHAINING_MODE
@@ -129,6 +119,7 @@ spec:
               command:
               - "/cni-install.sh"
               -{{- if .Values.global.debug.enabled }} "--enable-debug=true"{{- else }} "--enable-debug=false"{{- end }}
+              - "--cni-exclusive=true"
           preStop:
             exec:
               command:
@@ -373,16 +364,12 @@ spec:
           - secret:
               name: hubble-server-certs
               items:
+                - key: ca.crt
+                  path: client-ca.crt
                 - key: tls.crt
                   path: server.crt
                 - key: tls.key
                   path: server.key
-              optional: true
-          - configMap:
-              name: hubble-ca-cert
-              items:
-                - key: ca.crt
-                  path: client-ca.crt
               optional: true
 {{- if and .Values.global.ipMasqAgent .Values.global.ipMasqAgent.enabled }}
       - configMap:

--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -1,7 +1,6 @@
 {{- /*  Default values with backwards compatibility */ -}}
 {{- $defaultEnableCnpStatusUpdates := "true" -}}
 {{- $defaultBpfMapDynamicSizeRatio := 0.0 -}}
-{{- $defaultBpfMasquerade := "false" -}}
 {{- $defaultBpfClockProbe := "false" -}}
 {{- $defaultSessionAffinity := "false" -}}
 {{- $defaultOperatorApiServeAddr := "localhost:9234" -}}
@@ -13,7 +12,6 @@
 {{- if semverCompare ">=1.8" (default "1.8" .Values.upgradeCompatibility) -}}
 {{- $defaultEnableCnpStatusUpdates = "false" -}}
 {{- $defaultBpfMapDynamicSizeRatio = 0.0025 -}}
-{{- $defaultBpfMasquerade = "true" -}}
 {{- $defaultBpfClockProbe = "true" -}}
 {{- $defaultSessionAffinity = "true" -}}
 {{- if .Values.global.ipv4.enabled }}
@@ -240,6 +238,8 @@ data:
   bpf-map-dynamic-size-ratio: {{ $defaultBpfMapDynamicSizeRatio | quote }}
 {{- end }}
 
+  # bpf-lb-bypass-fib-lookup instructs Cilium to enable the FIB lookup bypass
+  # optimization for nodeport reverse NAT handling.
   # Pre-allocation of map entries allows per-packet latency to be reduced, at
   # the expense of up-front memory allocation for the entries in the maps. The
   # default value below will minimize memory usage in the default installation;
@@ -357,12 +357,10 @@ data:
 {{- end }}
 {{- end }}
 
-  masquerade: {{ .Values.global.masquerade | quote }}
-{{- if hasKey .Values "bpfMasquerade" }}
-  enable-bpf-masquerade: {{ .Values.bpfMasquerade | quote }}
-{{- else if eq $defaultBpfMasquerade "true" }}
-  enable-bpf-masquerade: {{ $defaultBpfMasquerade | quote }}
-{{- end }}
+  enable-ipv4-masquerade: {{ .Values.global.enableIpv4Masquerade | quote }}
+  enable-ipv6-masquerade: {{ .Values.global.enableIpv6Masquerade | quote }}
+  enable-bpf-masquerade: {{ .Values.global.enableBpfMasquerade | quote }}
+
 {{- if .Values.global.egressMasqueradeInterfaces }}
   egress-masquerade-interfaces: {{ .Values.global.egressMasqueradeInterfaces }}
 {{- end }}
@@ -388,6 +386,7 @@ data:
 {{- end }}
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
+  install-no-conntrack-iptables-rules: {{ .Values.global.installNoConntrackIptablesRules | quote }}
 {{- if .Values.global.iptablesLockTimeout }}
   iptables-lock-timeout: {{ .Values.global.iptablesLockTimeout | quote }}
 {{- end }}

--- a/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -77,14 +77,11 @@ spec:
           - secret:
               name: hubble-relay-client-certs
               items:
+                - key: ca.crt
+                  path: hubble-server-ca.crt
                 - key: tls.crt
                   path: client.crt
                 - key: tls.key
                   path: client.key
-          - configMap:
-              name: hubble-ca-cert
-              items:
-                - key: ca.crt
-                  path: hubble-server-ca.crt
         name: tls
 

--- a/charts/internal/cilium/charts/hubble-ui/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/configmap.yaml
@@ -16,31 +16,34 @@ data:
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager
-                  config:
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     codec_type: auto
                     stat_prefix: ingress_http
                     route_config:
                       name: local_route
                       virtual_hosts:
                         - name: local_service
-                          domains: ['*']
+                          domains: ["*"]
                           routes:
                             - match:
-                                prefix: '/api/'
+                                prefix: "/api/"
                               route:
                                 cluster: backend
-                                max_grpc_timeout: 0s
-                                prefix_rewrite: '/'
+                                prefix_rewrite: "/"
+                                timeout: 0s
+                                max_stream_duration:
+                                  grpc_timeout_header_max: 0s
                             - match:
-                                prefix: '/'
+                                prefix: "/"
                               route:
                                 cluster: frontend
                           cors:
                             allow_origin_string_match:
-                              - prefix: '*'
+                              - prefix: "*"
                             allow_methods: GET, PUT, DELETE, POST, OPTIONS
                             allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                            max_age: '1728000'
+                            max_age: "1728000"
                             expose_headers: grpc-status,grpc-message
                     http_filters:
                       - name: envoy.filters.http.grpc_web
@@ -51,16 +54,26 @@ data:
           connect_timeout: 0.25s
           type: strict_dns
           lb_policy: round_robin
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8080
+          load_assignment:
+            cluster_name: frontend
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8080
         - name: backend
           connect_timeout: 0.25s
           type: logical_dns
           lb_policy: round_robin
           http2_protocol_options: {}
-          hosts:
-            - socket_address:
-                address: 127.0.0.1
-                port_value: 8090
+          load_assignment:
+            cluster_name: frontend
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: 127.0.0.1
+                          port_value: 8090

--- a/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
@@ -25,6 +25,21 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # to perform LB IP allocation for BGP
+  - services/status
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
   # to automatically read from k8s and import the node's pod CIDR to cilium's
   # etcd so all nodes know how to reach another pod running in in a different
   # node.
@@ -74,12 +89,9 @@ rules:
 # For cilium-operator running in HA mode.
 #
 # Cilium operator running in HA mode requires the use of ResourceLock for Leader Election
-# between mulitple running instances.
+# between multiple running instances.
 # The preferred way of doing this is to use LeasesResourceLock as edits to Leases are less
 # common and fewer objects in the cluster watch "all Leases".
-# The support for leases was introduced in coordination.k8s.io/v1 during Kubernetes 1.14 release.
-# In Cilium we currently don't support HA mode for K8s version < 1.14. This condition make sure
-# that we only authorize access to leases resources in supported K8s versions.
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   name: cilium-operator
   namespace: {{ .Release.Namespace }}
 spec:
-  # We support HA mode only for Kubernetes version > 1.14
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.
   replicas: 1

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -130,9 +130,19 @@ global:
   # disabled.
   installIptablesRules: true
 
+  # This option, by default set to false,
+  # installs some extra Iptables rules to skip netfilter connection tracking on all pod traffic.
+  # Disabling connection tracking is only possible when Cilium is running
+  # in direct routing mode and is using the kube-proxy replacement.
+  # Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment
+  # or in a chained CNI setup.
+  installNoConntrackIptablesRules: false
+
   # masquerade enables masquerading of traffic leaving the ndoe for
   # destinations outside of the cluster.
-  masquerade: true
+  enableIpv4Masquerade: true
+  enableIpv6Masquerade: true
+  enableBpfMasquerade : true
 
   # ipMasqAgent enables and controls BPF ip-masq-agent
   ipMasqAgent:
@@ -286,7 +296,7 @@ global:
     # interface: eth0
 
   # kubeProxyReplacement enables kube-proxy replacement in Cilium BPF datapath
-  kubeProxyReplacement: "probe"
+  kubeProxyReplacement: "disabled"
   # The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable
   kubeProxyReplacementHealthzBindAddress: ""
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update cilium to `v1.10.1`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update cilium to `v1.10.1`
```
