### PR TITLE
Added kube-proxy clean up as init container in case cilium performs the service routing

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -39,3 +39,11 @@ images:
     sourceRepository: github.com/cilium/certgen
     repository: quay.io/cilium/certgen
     tag: v0.1.4
+  - name: kube-proxy
+    sourceRepository: github.com/kubernetes/kubernetes
+    repository: k8s.gcr.io/hyperkube
+    targetVersion: "< 1.17"
+  - name: kube-proxy
+    sourceRepository: github.com/kubernetes/kubernetes
+    repository: k8s.gcr.io/kube-proxy
+    targetVersion: ">= 1.17"

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -276,6 +276,45 @@ spec:
           name: cilium-run
         resources:
           {{- toYaml .Values.initResources | trim | nindent 10 }}
+{{- if eq .Values.global.kubeProxyReplacement "strict" }}
+      # Clean up kube-proxy iptable rules in case cilium is running as kube-proxy replacement
+{{- if not (eq .Values.kubeProxyCleanup "kube-proxy") }}
+      - command:
+        - bash
+        - -c
+        # Recommended way to clean up according to cilium docs (https://docs.cilium.io/en/latest/gettingstarted/kubeproxy-free/)
+        #- "iptables-restore <(iptables-save | grep -v KUBE)"
+        # Unfortunately, the above is not directly working due to etc/alternatives issue with cilium container image
+        # Therefore, we use the equivalent below, which adds also log output
+        - "iptables-save | grep -v KUBE > /saved-iptables-without-KUBE; echo 'IPTables without KUBE:'; cat /saved-iptables-without-KUBE; echo 'iptables-restore:'; iptables-restore --verbose /saved-iptables-without-KUBE"
+        image: {{ index .Values.global.images "cilium-agent" }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        name: cilium-kube-proxy-clean-up
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+{{- else }}
+      - command:
+        {{- if semverCompare "< 1.17" .Capabilities.KubeVersion.GitVersion }}
+        - /hyperkube
+        - kube-proxy
+        {{- else }}
+        - /usr/local/bin/kube-proxy
+        {{- end }}
+        - --cleanup
+        - --v=2
+        image: {{ index .Values.global.images "kube-proxy" }}
+        imagePullPolicy: {{ .Values.global.pullPolicy }}
+        name: kube-proxy-clean-up
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+          privileged: true
+{{- end }}
+{{- end }}
       restartPolicy: Always
 {{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
       priorityClassName: system-node-critical

--- a/charts/internal/cilium/charts/agent/values.yaml
+++ b/charts/internal/cilium/charts/agent/values.yaml
@@ -17,3 +17,6 @@ initResources:
   requests:
     cpu: "100m"
     memory: "100Mi"
+
+# Specifies whether to use the approach documented by cilium or kube-proxy to cleanup the iptables from kube-proxy
+kubeProxyCleanup: cilium-documentation

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -462,3 +462,4 @@ global:
     certgen: "image-repository:image-tag"
     envoy: "image-repository:image-tag"
 
+    kube-proxy: "image-repository:image-tag"

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -17,6 +17,7 @@ package charts
 import (
 	ciliumv1alpha1 "github.com/gardener/gardener-extension-networking-cilium/pkg/apis/cilium/v1alpha1"
 	"github.com/gardener/gardener-extension-networking-cilium/pkg/cilium"
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -27,8 +28,8 @@ import (
 const CiliumConfigKey = "config.yaml"
 
 // RenderCiliumChart renders the cilium chart with the given values.
-func RenderCiliumChart(renderer chartrenderer.Interface, config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network) ([]byte, error) {
-	values, err := ComputeCiliumChartValues(config, network)
+func RenderCiliumChart(renderer chartrenderer.Interface, config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) ([]byte, error) {
+	values, err := ComputeCiliumChartValues(config, network, cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cilium/types.go
+++ b/pkg/cilium/types.go
@@ -44,6 +44,9 @@ const (
 	// EnvoyImageName defines the envoy image name.
 	EnvoyImageName = "envoy"
 
+	// KubeProxyImageName defines the kube-proxy image name.
+	KubeProxyImageName = "kube-proxy"
+
 	// MonitoringChartName
 	MonitoringName = "cilium-monitoring-config"
 

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -89,7 +89,7 @@ func (a *actuator) Reconcile(ctx context.Context, network *extensionsv1alpha1.Ne
 		return errors.Wrapf(err, "could not create chart renderer for shoot '%s'", network.Namespace)
 	}
 
-	ciliumChart, err := charts.RenderCiliumChart(chartRenderer, networkConfig, network)
+	ciliumChart, err := charts.RenderCiliumChart(chartRenderer, networkConfig, network, cluster)
 	if err != nil {
 		return err
 	}

--- a/pkg/imagevector/image_finders.go
+++ b/pkg/imagevector/image_finders.go
@@ -2,11 +2,12 @@ package imagevector
 
 import (
 	"github.com/gardener/gardener-extension-networking-cilium/pkg/cilium"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
-func findImage(name string) string {
-	image, err := imageVector.FindImage(name)
+func findImage(name string, opts ...imagevector.FindOptionFunc) string {
+	image, err := imageVector.FindImage(name, opts...)
 	runtime.Must(err)
 	return image.String()
 }
@@ -59,4 +60,9 @@ func CiliumCertGenImage() string {
 // CiliumEnvoyImage returns the Envoy image.
 func CiliumEnvoyImage() string {
 	return findImage(cilium.EnvoyImageName)
+}
+
+// CiliumKubeProxyImage returns the kube-proxy image.
+func CiliumKubeProxyImage(kubernetesVersion string) string {
+	return findImage(cilium.KubeProxyImageName, imagevector.RuntimeVersion(kubernetesVersion), imagevector.TargetVersion(kubernetesVersion))
 }


### PR DESCRIPTION
Cilium documentation recommends to remove the iptables rules generated by kube-proxy before activating service routing in cilium.
Unfortunately, there is no easy way to execute a command on each node just once. Therefore, we simply use an init container of the daemon set.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Cilium documentation recommends to remove the iptables rules generated by kube-proxy before activating service routing in cilium.
Unfortunately, there is no easy way to execute a command on each node just once. Therefore, we simply use an init container of the daemon set.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
