### PR TITLE
Do not check the Seed K8s version for a supported K8s version

### DIFF
--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -34,8 +34,7 @@ type actuator struct {
 
 	client client.Client
 
-	gardenerClientset gardenerkubernetes.Interface
-	chartApplier      gardenerkubernetes.ChartApplier
+	chartApplier gardenerkubernetes.ChartApplier
 }
 
 // LogID is the id that will be used in log statements.
@@ -58,12 +57,9 @@ func (a *actuator) InjectConfig(config *rest.Config) error {
 	a.restConfig = config
 
 	var err error
-	a.gardenerClientset, err = gardenerkubernetes.NewWithConfig(gardenerkubernetes.WithRESTConfig(config))
+	a.chartApplier, err = gardenerkubernetes.NewChartApplierForConfig(config)
 	if err != nil {
-		return fmt.Errorf("could not create Gardener client: %w", err)
+		return fmt.Errorf("could not create ChartApplier: %w", err)
 	}
-
-	a.chartApplier = a.gardenerClientset.ChartApplier()
-
 	return nil
 }


### PR DESCRIPTION
/area networking
/kind enhancement

Similar to https://github.com/gardener/gardener-extension-networking-calico/pull/111/

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension does no longer depend on a list of supported Kubernetes versions (coming from the `github.com/gardener/gardener` dependency). This was preventing the extension to start against Seed clusters running on K8s versions that were not present in the mentioned list.
```
