### PR TITLE
Use right apiversion for cronjob

### DIFF
--- a/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: {{- if semverCompare ">= 1.21" .Capabilities.KubeVersion.GitVersion }} batch/v1 {{- else }} batch/v1beta1 {{- end }}
 kind: CronJob
 metadata:
   name: hubble-generate-certs

--- a/charts/utils-templates/templates/_versions.tpl
+++ b/charts/utils-templates/templates/_versions.tpl
@@ -47,7 +47,7 @@ scheduling.k8s.io/v1
 {{- end -}}
 
 {{- define "cronjobversion" -}}
-batch/v1beta1
+batch/v1
 {{- end -}}
 
 {{- define "hpaversion" -}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Use the correct api-version for hubble-generate-certs cronjob.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
