### PR TITLE
Add init container to cilium agent which disables rp_filter

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -249,6 +249,17 @@ spec:
 {{- end }}
       hostNetwork: true
       initContainers:
+      # Disable source validation / rp_filter.
+      - name: disable-rp-filter
+        image: {{ index .Values.global.images "cilium-agent" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - sh
+        - -c
+        - "sed -i 's/^net.ipv4.conf.all.rp_filter/#net.ipv4.conf.all.rp_filter/g' /host/etc/sysctl.d/*"
+        volumeMounts:
+        - name: host-etc
+          mountPath: /host/etc
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
@@ -424,6 +435,11 @@ spec:
           path: {{ .Values.global.nodeinit.bootstrapFile }}
           type: FileOrCreate
 {{- end }}
+      # To mount /etc directory
+      - name: host-etc
+        hostPath:
+          path: /etc
+          type: Directory
 {{- if .Values.global.etcd.enabled }}
         # To read the etcd config stored in config maps
       - configMap:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Add init container to cilium agent which disables reverse path filtering (rp_filter).

**Which issue(s) this PR fixes**:
Fixes #51

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add init container to cilium agent which disables reverse path filtering (rp_filter).

```
