### PR TITLE
Added cilium network policy to allow non-pod entities on remote nodes to access the cluster dns server.

### DIFF
--- a/charts/internal/cilium/charts/network-policy/Chart.yaml
+++ b/charts/internal/cilium/charts/network-policy/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+name: network-policy
+version: 0.1.0
+description: Helm chart for cilium related network policies
+sources:
+  - https://github.com/gardener/gardener-extension-networking-cilium

--- a/charts/internal/cilium/charts/network-policy/templates/dns.yaml
+++ b/charts/internal/cilium/charts/network-policy/templates/dns.yaml
@@ -1,0 +1,23 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: "Allows CoreDNS to be reachable by non-pod remote node IPs, in particular Cilium DNS proxies."
+  name: gardener.cloud--allow-dns-from-remote-nodes
+  namespace: kube-system
+spec:
+  endpointSelector:
+    matchExpressions:
+    - key: k8s-app
+      operator: In
+      values:
+      - kube-dns
+  ingress:
+  - fromEntities:
+    - remote-node
+    toPorts:
+    - ports:
+      - port: "8053"
+        protocol: TCP
+      - port: "8053"
+        protocol: UDP


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Added cilium network policy to allow non-pod entities on remote nodes to access the cluster dns server.

In case cilium's dns based policy rules are utilized the dns traffic is redirected through a proxy component
owned by cilium. However, this proxy component needs to be allowed to perform dns requests. The default
network policy does not seem to be sufficient. Therefore, we add this special policy in addition.

**Which issue(s) this PR fixes**:
Fixes #35

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added cilium network policy to allow cilium's dns proxy to perform dns requests to make dns based policy working.
```
