### PR TITLE
Improved the disablement of the reverse path filter so that it works better across operating systems.

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -256,7 +256,7 @@ spec:
         command:
         - sh
         - -c
-        - "sed -i 's/^net.ipv4.conf.all.rp_filter/#net.ipv4.conf.all.rp_filter/g' /host/etc/sysctl.d/*"
+        - "echo 'net.ipv4.conf.all.rp_filter=0' > /host/etc/sysctl.d/99-cilium-rp-filter.conf"
         volumeMounts:
         - name: host-etc
           mountPath: /host/etc


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Improved the disablement of the reverse path filter so that it works better across operating systems.

Some operating systems include sysctl configurations not only in /etc/sysctl.d, but also in the /usr tree.
It is easier and safer to simply add a configuration template disabling the reverse path filter altogether.

**Which issue(s) this PR fixes**:
Fixes issues with https://github.com/gardener/gardener-extension-os-suse-chost setting `rp_filter` in non /etc configuration files.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disables rp_filter properly when running cilium on all operating systems
```
