### PR TITLE
Add memory requests and limits to cilium agent container.

### DIFF
--- a/charts/internal/cilium/charts/agent/values.yaml
+++ b/charts/internal/cilium/charts/agent/values.yaml
@@ -10,7 +10,11 @@ monitor:
   resources: {}
 
 # Specifies the resources for the agent container
-resources: {}
+resources:
+  requests:
+    memory: 200Mi
+  limits:
+    memory: 1Gi
 
 # Specifies the resources for the clean-cilium-state init container
 initResources:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add memory requests and limits to cilium agent container.

We want to limit the memory consumption of cilium agent in case of bugs.
The way we set the limits we also have to specify the requests. Otherwise,
the requests will be equal to the limits, which would be wasteful.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added default memory resource requests/limits to cilium-agent.
```
