### PR TITLE
Update cilium to v1.11.5

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,15 +2,15 @@ images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.11.3
+    tag: v1.11.5
   - name: cilium-preflight
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.11.3
+    tag: v1.11.5
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/operator
-    tag: v1.11.3
+    tag: v1.11.5
   - name: cilium-etcd-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium-etcd-operator
@@ -34,7 +34,7 @@ images:
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-relay
-    tag: v1.11.3
+    tag: v1.11.5
   - name: certgen
     sourceRepository: github.com/cilium/certgen
     repository: quay.io/cilium/certgen

--- a/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
@@ -24,34 +24,19 @@ rules:
   resources:
   - namespaces
   - services
-  - nodes
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - nodes
   - pods
+  - endpoints
+  - nodes
   verbs:
   - get
   - list
   - watch
-  - update
 - apiGroups:
   - ""
   resources:
-  - nodes
   - nodes/status
   verbs:
+  # To annotate the k8s node with Cilium's metadata
   - patch
 - apiGroups:
   - apiextensions.k8s.io
@@ -80,18 +65,13 @@ rules:
   resources:
   - ciliumnetworkpolicies
   - ciliumnetworkpolicies/status
-  - ciliumnetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies
   - ciliumclusterwidenetworkpolicies/status
-  - ciliumclusterwidenetworkpolicies/finalizers
   - ciliumendpoints
   - ciliumendpoints/status
-  - ciliumendpoints/finalizers
   - ciliumnodes
   - ciliumnodes/status
-  - ciliumnodes/finalizers
   - ciliumidentities
-  - ciliumidentities/finalizers
   - ciliumlocalredirectpolicies
   - ciliumlocalredirectpolicies/status
   - ciliumegressnatpolicies

--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -82,6 +82,9 @@ data:
 {{- if .Values.global.endpointGCInterval }}
   cilium-endpoint-gc-interval: "{{ .Values.global.endpointGCInterval }}"
 {{- end }}
+{{- if .Values.global.nodesGCInterval }}
+  nodes-gc-interval: "5m0s"
+{{- end }}
 {{- if .Values.global.disableEndpointCrd }}
   disable-endpoint-crd: "{{ .Values.global.disableEndpointCrd }}"
 {{- end }}
@@ -474,6 +477,9 @@ kube-proxy-replacement-healthz-bind-address: "{{ .Values.global.kubeProxyReplace
 {{- if .Values.global.l2NeighDiscovery.enabled }}
   enable-l2-neigh-discovery: {{ .Values.global.l2NeighDiscovery.enabled | quote }}
 {{- end }}
+{{- if .Values.global.arpingRefreshPeriod }}
+  arping-refresh-period: {{ .Values.global.arpingRefreshPeriod }}
+{{- end }}
 {{- if and .Values.global.pprof .Values.global.pprof.enabled }}
   pprof: {{ .Values.global.pprof.enabled | quote }}
 {{- end }}
@@ -582,6 +588,10 @@ kube-proxy-replacement-healthz-bind-address: "{{ .Values.global.kubeProxyReplace
 
   cgroup-root: "/run/cilium/cgroupv2"
   enable-k8s-terminating-endpoint: "true"
+  annotate-k8s-node: "true"
+  remove-cilium-node-taints: "true"
+  set-cilium-is-up-condition: "true"
+  unmanaged-pod-watcher-interval: "15"
 
 {{- if hasKey .Values "blacklistConflictingRoutes" }}
   # Configure blacklisting of local routes not owned by Cilium.

--- a/charts/internal/cilium/charts/hubble-relay/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/configmap.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |
-    peer-service: unix://{{ .Values.global.hubble.socketPath }}
+    cluster-name: {{ .Values.global.hubble.clusterName }}
+    peer-service: {{ .Values.global.hubble.peerService }}
     listen-address: {{ .Values.listenHost }}:{{ .Values.listenPort }}
     dial-timeout: {{ .Values.dialTimeout }}
     retry-timeout: {{ .Values.retryTimeout }}

--- a/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -47,9 +47,6 @@ spec:
 {{- toYaml .Values.resources | trim | nindent 10 }}
 {{- end }}
           volumeMounts:
-          - name: hubble-sock-dir
-            mountPath: {{ dir .Values.global.hubble.socketPath }}
-            readOnly: true
           - name: config
             mountPath: /etc/hubble-relay
             readOnly: true
@@ -63,10 +60,6 @@ spec:
       tolerations:
       - operator: Exists
       volumes:
-      - name: hubble-sock-dir
-        hostPath:
-          path: {{ dir .Values.global.hubble.socketPath }}
-          type: Directory
       - name: config
         configMap:
           name: hubble-relay-config

--- a/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         runAsUser: 1001
+        runAsGroup: 1001
+        fsGroup: 1001
       {{- end }}
       serviceAccountName: hubble-ui
       serviceAccount: hubble-ui

--- a/charts/internal/cilium/charts/hubble-ui/templates/hubble-peer-svc.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/hubble-peer-svc.yaml
@@ -1,0 +1,17 @@
+# Source: cilium/templates/hubble/peer-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-peer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: cilium
+spec:
+  selector:
+    k8s-app: cilium
+  ports:
+  - name: peer-service
+    port: 4254
+    protocol: TCP
+    targetPort: 4244
+  internalTrafficPolicy: Local

--- a/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
@@ -6,14 +6,30 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to automatically delete [core|kube]dns pods so that are starting to being
-  # managed by Cilium
   - pods
   verbs:
   - get
   - list
   - watch
+  # to automatically delete [core|kube]dns pods so that are starting to being
+  # managed by Cilium
   - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  # To remove node taints
+  - nodes
+  # To set NetworkUnavailable false on startup
+  - nodes/status
+  verbs:
+  - patch
 - apiGroups:
   - discovery.k8s.io
   resources:

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -29,7 +29,8 @@ global:
   pullPolicy: IfNotPresent
 
   hubble:
-    socketPath: /var/run/cilium/hubble.sock
+    clusterName: default
+    peerService: "hubble-peer.kube-system.svc.cluster.local:4254"
     enabled: true
     listenAddress: ":4244"
     metrics:
@@ -75,7 +76,9 @@ global:
   #  kvstore: Key-value store backend (better scalability)
   identityAllocationMode: crd
 
-  endpointGCInterval: 5m0s
+  endpointGCInterval: "5m0s"
+
+  nodesGCInterval: "5m0s"
 
   # Disable the usage of CiliumEndpoint CRD
   disableEndpointCrd: false
@@ -438,6 +441,9 @@ global:
 
   l2NeighDiscovery:
     enabled: true
+
+  # Period for remote node ARP entry refresh
+  arpingRefreshPeriod: "30s"
 
   endpointHealthChecking:
     enabled: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update cilium to v1.11.5. For more information see the [release notes](https://github.com/cilium/cilium/releases/tag/v1.11.5).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update cilium to v1.11.5.
```
