### PR TITLE
Consider tunnel mode and debug option in the provider config during reconciliation.

### DIFF
--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -166,5 +166,15 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 	if config.BPFSocketLBHostnsOnly != nil {
 		globalConfig.BPFSocketLBHostnsOnly.Enabled = config.BPFSocketLBHostnsOnly.Enabled
 	}
+
+	// check if tunnel mode is set
+	if config.TunnelMode != nil {
+		globalConfig.Tunnel = *config.TunnelMode
+	}
+
+	// check if debug is set
+	if config.Debug != nil {
+		globalConfig.Debug.Enabled = *config.Debug
+	}
 	return requirementsConfig, globalConfig, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Consider tunnel mode and debug option in the provider config during reconciliation.

The documentation stated that tunnel mode and debug option could be set in the
provider configuration. Unfortunately, the values were ignored in the past.
This change should fix that.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Tunnel mode and debug option are now properly handled when specified in the cilium provider configuration.
```
