### PR TITLE
Add default memory requests/limits to hubble-relay container.

### DIFF
--- a/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               port: grpc
 {{- if .Values.resources }}
           resources:
-{{- toYaml .Values.resources | trim | nindent 10 }}
+{{- toYaml .Values.resources | trim | nindent 12 }}
 {{- end }}
           volumeMounts:
           - name: config

--- a/charts/internal/cilium/charts/hubble-relay/values.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/values.yaml
@@ -1,5 +1,9 @@
 # Specifies the resources for the hubble-relay pods
-resources: {}
+resources:
+  requests:
+    memory: 150Mi
+  limits:
+    memory: 1Gi
 
 # Number of replicas run for the hubble-relay deployment.
 numReplicas: 1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add default memory requests/limits to hubble-relay container.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add default memory requests/limits to cilium/hubble-relay container.
```
