### PR TITLE
Exclude some linter checks which don't work with golang v1.18

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,23 @@
 run:
   concurrency: 4
   deadline: 10m
+  # some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
+  # we are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
+  go: "1.17"
 
 linters:
   disable:
     - unused
+
+issues:
+  exclude-use-default: false
+  exclude:
+  # typecheck:
+  - "undeclared name: `.*`"
+  - "\".*\" imported but not used"
+  - "could not import .*"
+  - ".* declared but not used"
+  exclude-rules:
+  - linters:
+    - staticcheck
+    text: "SA1019:" # Excludes messages where deprecated variables are used


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Some of the linters don't work correctly with 1.18, ref https://github.com/golangci/golangci-lint/issues/2649
 We are not using generics, so let's pin this to 1.17 until 1.18 is fully supported
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
