### PR TITLE
use distroless image for garnder networking cilium extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ COPY . .
 RUN make install
 
 ############# gardener-extension-networking-cilium
-FROM alpine:3.13.7 AS gardener-extension-networking-cilium
+FROM gcr.io/distroless/static-debian11:nonroot AS gardener-extension-networking-cilium
+WORKDIR /
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-networking-cilium /gardener-extension-networking-cilium


### PR DESCRIPTION
**How to categorize this PR?**

/area networking security open-source
/kind enhancement

**What this PR does / why we need it**:
This PR changes the base image for networking and admission services from alpine to [distroless](https://github.com/GoogleContainerTools/distroless). The processes will now use a non root user for their execution. This will reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension now uses `distroless` instead of `alpine` as a base image.
```
