### PR TITLE
Update cilium to v1.12.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,15 +2,15 @@ images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.11.6
+    tag: v1.12.0
   - name: cilium-preflight
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.11.6
+    tag: v1.12.0
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/operator
-    tag: v1.11.6
+    tag: v1.12.0
   - name: cilium-etcd-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium-etcd-operator
@@ -30,11 +30,11 @@ images:
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-relay
-    tag: v1.11.6
+    tag: v1.12.0
   - name: certgen
     sourceRepository: github.com/cilium/certgen
     repository: quay.io/cilium/certgen
-    tag: v0.1.5
+    tag: v0.1.8
   - name: kube-proxy
     sourceRepository: github.com/kubernetes/kubernetes
     repository: k8s.gcr.io/hyperkube

--- a/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/agent/templates/clusterrole.yaml
@@ -32,22 +32,12 @@ rules:
   - list
   - watch
 - apiGroups:
-  - ""
-  resources:
-  - nodes/status
-  verbs:
-  # To annotate the k8s node with Cilium's metadata
-  - patch
-- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
-  # Deprecated for removal in v1.10
-  - create
   - list
   - watch
-  - update
   # This is used when validating policies in preflight. This will need to stay
   # until we figure out how to avoid "get" inside the preflight, and then
   # should be removed ideally.
@@ -63,19 +53,58 @@ rules:
 - apiGroups:
   - cilium.io
   resources:
-  - ciliumnetworkpolicies
-  - ciliumnetworkpolicies/status
+  - ciliumbgploadbalancerippools
+  - ciliumbgppeeringpolicies
+  - ciliumclusterwideenvoyconfigs
   - ciliumclusterwidenetworkpolicies
-  - ciliumclusterwidenetworkpolicies/status
+  - ciliumegressgatewaypolicies
+  - ciliumegressnatpolicies
   - ciliumendpoints
-  - ciliumendpoints/status
-  - ciliumnodes
-  - ciliumnodes/status
+  - ciliumendpointslices
+  - ciliumenvoyconfigs
   - ciliumidentities
   - ciliumlocalredirectpolicies
-  - ciliumlocalredirectpolicies/status
-  - ciliumlocalredirectpolicies/finalizers
-  - ciliumegressnatpolicies
-  - ciliumendpointslices
+  - ciliumnetworkpolicies
+  - ciliumnodes
   verbs:
-  - '*'
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  - ciliumendpoints
+  - ciliumnodes
+  verbs:
+  - create
+- apiGroups:
+  - cilium.io
+  # To synchronize garbage collection of such resources
+  resources:
+  - ciliumidentities
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints
+  verbs:
+  - delete
+  - get
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  - ciliumnodes/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/status
+  - ciliumendpoints/status
+  - ciliumendpoints
+  verbs:
+  - patch

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -18,13 +18,16 @@ spec:
         prometheus.io/port: "{{ .Values.global.prometheus.port }}"
         prometheus.io/scrape: "true"
 {{- end }}
+        # Set app AppArmor's profile to "unconfined". The value of this annotation
+        # can be modified as long users know which profiles they have available
+        # in AppArmor.
+        container.apparmor.security.beta.kubernetes.io/cilium-agent: "unconfined"
+        container.apparmor.security.beta.kubernetes.io/clean-cilium-state: "unconfined"
+        container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
+        container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
       labels:
         k8s-app: cilium
     spec:
-{{- if .Values.global.affinity }}
-      affinity:
-{{ toYaml .Values.global.affinity | indent 8 }}
-{{- end }}
       containers:
 {{- if .Values.global.sleepAfterInit }}
       - command: [ "/bin/bash", "-c", "--" ]
@@ -143,6 +146,7 @@ spec:
               - "/cni-install.sh"
               -{{- if .Values.global.debug.enabled }} "--enable-debug=true"{{- else }} "--enable-debug=false"{{- end }}
               - "--cni-exclusive=true"
+              - "--log-file=/var/run/cilium/cilium-cni.log"
           preStop:
             exec:
               command:
@@ -165,13 +169,59 @@ spec:
           protocol: TCP
 {{- end }}
         securityContext:
-          privileged: true
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            add:
+              # Use to set socket permission
+              - CHOWN
+              # Used to terminate envoy child process
+              - KILL
+              # Used since cilium modifies routing tables, etc...
+              - NET_ADMIN
+              # Used since cilium creates raw sockets, etc...
+              - NET_RAW
+              # Used since cilium monitor uses mmap
+              - IPC_LOCK
+              # Used in iptables. Consider removing once we are iptables-free
+              - SYS_MODULE
+              # We need it for now but might not need it for >= 5.11 specially
+              # for the 'SYS_RESOURCE'.
+              # In >= 5.8 there's already BPF and PERMON capabilities
+              - SYS_ADMIN
+              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+              - SYS_RESOURCE
+              # Both PERFMON and BPF requires kernel 5.8, container runtime
+              # cri-o >= v1.22.0 or containerd >= v1.5.0.
+              # If available, SYS_ADMIN can be removed.
+              #- PERFMON
+              #- BPF
+              - DAC_OVERRIDE
+              - FOWNER
+              - SETGID
+              - SETUID
+            drop:
+              - ALL
         volumeMounts:
-{{- /* CRI-O already mounts the BPF filesystem */ -}}
-{{- if not (eq .Values.global.containerRuntime.integration "crio") }}
+        # Unprivileged containers need to mount /proc/sys/net from the host
+        # to have write access
+        - mountPath: /host/proc/sys/net
+          name: host-proc-sys-net
+        # Unprivileged containers need to mount /proc/sys/kernel from the host
+        # to have write access
+        - mountPath: /host/proc/sys/kernel
+          name: host-proc-sys-kernel
         - name: bpf-maps
           mountPath: /sys/fs/bpf
-{{- end }}
+          # Unprivileged containers can't set mount propagation to bidirectional
+          # in this case we will mount the bpf fs from an init container that
+          # is privileged and set the mount propagation from host to container
+          # in Cilium.
+          mountPropagation: HostToContainer
         - name: cilium-run
           mountPath: /var/run/cilium
         - name: cni-path
@@ -243,7 +293,6 @@ spec:
       # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
-      hostNetwork: true
       initContainers:
       # Disable source validation / rp_filter.
       - name: disable-rp-filter
@@ -256,6 +305,16 @@ spec:
         volumeMounts:
         - name: host-etc
           mountPath: /host/etc
+        securityContext:
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            drop:
+              - ALL
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
@@ -284,7 +343,78 @@ spec:
           - name: cni-path
             mountPath: /hostbin
         securityContext:
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            drop:
+              - ALL
+            add:
+              # Only used for 'mount' cgroup
+              - SYS_ADMIN
+              # Used for nsenter
+              - SYS_CHROOT
+              - SYS_PTRACE
+      - name: apply-sysctl-overwrites
+        image: {{ index .Values.global.images "cilium-agent" }}
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: BIN_PATH
+          value: /opt/cni/bin
+        command:
+        - sh
+        - -ec
+        # The statically linked Go program binary is invoked to avoid any
+        # dependency on utilities like sh that can be missing on certain
+        # distros installed on the underlying host. Copy the binary to the
+        # same directory where we install cilium cni plugin so that exec permissions
+        # are available.
+        - |
+          cp /usr/bin/cilium-sysctlfix /hostbin/cilium-sysctlfix;
+          nsenter --mount=/hostproc/1/ns/mnt "${BIN_PATH}/cilium-sysctlfix";
+          rm /hostbin/cilium-sysctlfix
+        volumeMounts:
+        - name: hostproc
+          mountPath: /hostproc
+        - name: cni-path
+          mountPath: /hostbin
+        securityContext:
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            drop:
+              - ALL
+            add:
+              # Required in order to access host's /etc/sysctl.d dir
+              - SYS_ADMIN
+              # Used for nsenter
+              - SYS_CHROOT
+              - SYS_PTRACE
+      # Mount the bpf fs if it is not mounted. We will perform this task
+      # from a privileged container because the mount propagation bidirectional
+      # only works from privileged containers.
+      - name: mount-bpf-fs
+        image: {{ index .Values.global.images "cilium-agent" }}
+        imagePullPolicy: IfNotPresent
+        args:
+        - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
+        command:
+        - /bin/bash
+        - -c
+        - --
+        securityContext:
           privileged: true
+        volumeMounts:
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
 {{- if and .Values.global.nodeinit.enabled (not (eq .Values.global.nodeinit.bootstrapFile "")) }}
       - name: wait-for-node-init
         command: ['sh', '-c', 'until stat {{ .Values.global.nodeinit.bootstrapFile }} > /dev/null 2>&1; do echo "Waiting on node-init to run..."; sleep 1; done']
@@ -294,7 +424,8 @@ spec:
         - mountPath: {{ .Values.global.nodeinit.bootstrapFile }}
           name: cilium-bootstrap-file
 {{- end }}
-      - command:
+      - name: clean-cilium-state
+        command:
         - /init-container.sh
         env:
         - name: CILIUM_ALL_STATE
@@ -311,9 +442,36 @@ spec:
               optional: true
         image: {{ index .Values.global.images "cilium-agent" }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
-        name: clean-cilium-state
         securityContext:
-          privileged: true
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            # Most of the capabilities here are the same ones used in the
+            # cilium-agent's container because this container can be used to
+            # uninstall all Cilium resources, and therefore it is likely that
+            # will need the same capabilities.
+            add:
+              # Used since cilium modifies routing tables, etc...
+              - NET_ADMIN
+              # Used in iptables. Consider removing once we are iptables-free
+              - SYS_MODULE
+              # We need it for now but might not need it for >= 5.11 specially
+              # for the 'SYS_RESOURCE'.
+              # In >= 5.8 there's already BPF and PERMON capabilities
+              - SYS_ADMIN
+              # Could be an alternative for the SYS_ADMIN for the RLIMIT_NPROC
+              - SYS_RESOURCE
+              # Both PERFMON and BPF requires kernel 5.8, container runtime
+              # cri-o >= v1.22.0 or containerd >= v1.5.0.
+              # If available, SYS_ADMIN can be removed.
+              #- PERFMON
+              #- BPF
+            drop:
+              - ALL
         volumeMounts:
 {{- /* CRI-O already mounts the BPF filesystem */ -}}
 {{- if not (eq .Values.global.containerRuntime.integration "crio") }}
@@ -371,11 +529,18 @@ spec:
 {{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
       priorityClassName: system-node-critical
 {{- end }}
-      serviceAccount: cilium
-      serviceAccountName: cilium
+      serviceAccount: "cilium"
+      serviceAccountName: "cilium"
       terminationGracePeriodSeconds: 1
+      hostNetwork: true
+{{- if .Values.global.affinity }}
+      affinity:
+{{ toYaml .Values.global.affinity | indent 8 }}
+{{- end }}
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
-      - operator: Exists
+        - operator: Exists
       volumes:
         # To keep state between restarts / upgrades
       - name: cilium-run
@@ -465,6 +630,14 @@ spec:
       - name: cilium-config-path
         configMap:
           name: cilium-config
+      - name: host-proc-sys-net
+        hostPath:
+          path: /proc/sys/net
+          type: Directory
+      - name: host-proc-sys-kernel
+        hostPath:
+          path: /proc/sys/kernel
+          type: Directory
       - name: hubble-tls
         projected:
           # note: the leading zero means this number is in octal representation: do not remove it

--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -248,6 +248,10 @@ data:
   # optimization for nodeport reverse NAT handling.
   bpf-lb-external-clusterip: "{{ .Values.global.bpf.lbExternalClusterip }}"
 {{- end }}
+
+  # Enable socket-based LB for E/W traffic
+  bpf-lb-sock:  "{{ .Values.global.bpfSocketLB.enabled }}"
+
 {{- if .Values.global.bpfSocketLBHostnsOnly.enabled }}
   # bpf-lb-sock-hostns-only skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface.
   # Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
@@ -331,9 +335,7 @@ data:
   install-no-conntrack-iptables-rules: {{ .Values.global.installNoConntrackIptablesRules | quote }}
 
   auto-direct-node-routes: {{ .Values.global.autoDirectNodeRoutes | quote }}
-{{- if .Values.global.bandwidthManager.enabled }}
-  enable-bandwidth-manager: {{ .Values.global.bandwidthManager.enabled | quote }}
-{{- end }}
+
 {{- if .Values.global.localRedirectPolicy.enabled }}
   enable-local-redirect-policy: {{ .Values.global.localRedirectPolicy.enabled | quote }}
 {{- end }}
@@ -475,6 +477,7 @@ kube-proxy-replacement-healthz-bind-address: "{{ .Values.global.kubeProxyReplace
 {{- end }}
   node-port-bind-protection: {{ .Values.global.nodePort.bindProtection | quote }}
   enable-auto-protect-node-port-range: {{ .Values.global.nodePort.autoProtectPortRange | quote }}
+  enable-svc-source-range-check: {{ .Values.global.enableSvcSrcRangeCheck | quote }}
 {{- end }}
 {{- if hasKey .Values "sessionAffinity" }}
   enable-session-affinity: {{ .Values.sessionAffinity | quote }}
@@ -593,12 +596,28 @@ kube-proxy-replacement-healthz-bind-address: "{{ .Values.global.kubeProxyReplace
   disable-cnp-status-updates: "true"
 {{- end }}
 
+  enable-vtep: "false"
+  vtep-endpoint: ""
+  vtep-cidr: ""
+  vtep-mask: ""
+  vtep-mac: ""
+  enable-bgp-control-plane: "false"
+  procfs: "/host/proc"
+  bpf-root: "/sys/fs/bpf"
   cgroup-root: "/run/cilium/cgroupv2"
   enable-k8s-terminating-endpoint: "true"
+
   annotate-k8s-node: "true"
   remove-cilium-node-taints: "true"
   set-cilium-is-up-condition: "true"
   unmanaged-pod-watcher-interval: "15"
+  tofqdns-dns-reject-response-code: "refused"
+  tofqdns-enable-dns-compression: "true"
+  tofqdns-endpoint-max-ip-per-hostname: "50"
+  tofqdns-idle-connection-grace-period: "0s"
+  tofqdns-max-deferred-connection-deletes: "10000"
+  tofqdns-min-ttl: "3600"
+  tofqdns-proxy-response-max-delay: "100ms"
   agent-not-ready-taint-key: "node.cilium.io/agent-not-ready"
 
 {{- if hasKey .Values "blacklistConflictingRoutes" }}

--- a/charts/internal/cilium/charts/hubble-relay/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/clusterrole.yaml
@@ -44,6 +44,7 @@ rules:
     resources:
       - secrets
     resourceNames:
+      - cilium-ca
       - hubble-ca-secret
     verbs:
       - get

--- a/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
@@ -27,8 +27,8 @@ spec:
               # the values used in past runs by inspecting the completed pod.
               args:
                 - "--cilium-namespace=kube-system"
-                - "--hubble-ca-generate"
-                - "--hubble-ca-reuse-secret"
+                - "--ca-generate"
+                - "--ca-reuse-secret"
                 - "--hubble-server-cert-generate"
                 - "--hubble-server-cert-common-name=*.{{ .Values.global.cluster.name }}.hubble-grpc.cilium.io"
                 - "--hubble-server-cert-validity-duration=94608000s"

--- a/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -56,9 +56,16 @@ spec:
       restartPolicy: Always
       serviceAccountName: hubble-relay
       automountServiceAccountToken: false
-      terminationGracePeriodSeconds: 0
-      tolerations:
-      - operator: Exists
+      terminationGracePeriodSeconds: 1
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                k8s-app: cilium
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
       - name: config
         configMap:

--- a/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
@@ -24,8 +24,8 @@ spec:
           # the values used in past runs by inspecting the completed pod.
           args:
             - "--cilium-namespace=kube-system"
-            - "--hubble-ca-generate"
-            - "--hubble-ca-reuse-secret"
+            - "--ca-generate"
+            - "--ca-reuse-secret"
             - "--hubble-server-cert-generate"
             - "--hubble-server-cert-common-name=*.{{ .Values.global.cluster.name }}.hubble-grpc.cilium.io"
             - "--hubble-server-cert-validity-duration=94608000s"

--- a/charts/internal/cilium/charts/hubble-relay/templates/service.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-app: {{ .Chart.Name }}
 spec:
-  type: ClusterIP
+  type: "ClusterIP"
   selector:
     k8s-app: {{ .Chart.Name }}
   ports:

--- a/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -18,9 +18,9 @@ spec:
     spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
-        runAsUser: 1001
-        runAsGroup: 1001
         fsGroup: 1001
+        runAsGroup: 1001
+        runAsUser: 1001
       {{- end }}
       serviceAccountName: hubble-ui
       serviceAccount: hubble-ui
@@ -35,6 +35,8 @@ spec:
             - name: hubble-ui-nginx-conf
               mountPath: /etc/nginx/conf.d/default.conf
               subPath: nginx.conf
+            - name: tmp-dir
+              mountPath: /tmp
           resources:
             limits:
               cpu: 1000m
@@ -60,8 +62,12 @@ spec:
             requests:
               cpu: 100m
               memory: 64Mi
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
       - configMap:
           defaultMode: 420
           name: hubble-ui-nginx
         name: hubble-ui-nginx-conf
+      - emptyDir: {}
+        name: tmp-dir

--- a/charts/internal/cilium/charts/hubble-ui/templates/svc.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/svc.yaml
@@ -13,4 +13,4 @@ spec:
     - name: http
       port: 80
       targetPort: 8081
-  type: ClusterIP
+  type: "ClusterIP"

--- a/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
+++ b/charts/internal/cilium/charts/operator/templates/clusterrole.yaml
@@ -41,14 +41,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   # to perform LB IP allocation for BGP
   - services/status
   verbs:
@@ -56,15 +48,18 @@ rules:
 - apiGroups:
   - ""
   resources:
-  # to automatically read from k8s and import the node's pod CIDR to cilium's
-  # etcd so all nodes know how to reach another pod running in in a different
-  # node.
-  - nodes
+  # to check apiserver connectivity
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   # to perform the translation of a CNP that contains `ToGroup` to its endpoints
   - services
   - endpoints
-  # to check apiserver connectivity
-  - namespaces
   verbs:
   - get
   - list
@@ -73,36 +68,103 @@ rules:
   - cilium.io
   resources:
   - ciliumnetworkpolicies
-  - ciliumnetworkpolicies/status
-  - ciliumnetworkpolicies/finalizers
   - ciliumclusterwidenetworkpolicies
-  - ciliumclusterwidenetworkpolicies/status
-  - ciliumclusterwidenetworkpolicies/finalizers
-  - ciliumendpoints
-  - ciliumendpoints/status
-  - ciliumendpoints/finalizers
-  - ciliumnodes
-  - ciliumnodes/status
-  - ciliumnodes/finalizers
-  - ciliumidentities
-  - ciliumendpointslices
-  - ciliumidentities/status
-  - ciliumidentities/finalizers
-  - ciliumlocalredirectpolicies
-  - ciliumlocalredirectpolicies/status
-  - ciliumlocalredirectpolicies/finalizers
   verbs:
-  - '*'
+  # Create auto-generated CNPs and CCNPs from Policies that have 'toGroups'
+  - create
+  - update
+  - deletecollection
+  # To update the status of the CNPs and CCNPs
+  - patch
+  - get
+  - list
+  - watch
 - apiGroups:
-    - apiextensions.k8s.io
+  - cilium.io
   resources:
-    - customresourcedefinitions
+  - ciliumnetworkpolicies/status
+  - ciliumclusterwidenetworkpolicies/status
+  verbs:
+  # Update the auto-generated CNPs and CCNPs status.
+  - patch
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpoints
+  - ciliumidentities
+  verbs:
+  # To perform garbage collection of such resources
+  - delete
+  - list
+  - watch
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumidentities
+  verbs:
+  # To synchronize garbage collection of such resources
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - watch
+    # To perform CiliumNode garbage collector
+  - delete
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumnodes/status
+  verbs:
+  - update
+- apiGroups:
+  - cilium.io
+  resources:
+  - ciliumendpointslices
+  - ciliumenvoyconfigs
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
   verbs:
   - create
   - get
   - list
-  - update
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - update
+  resourceNames:
+  - ciliumbgploadbalancerippools.cilium.io
+  - ciliumbgppeeringpolicies.cilium.io
+  - ciliumclusterwideenvoyconfigs.cilium.io
+  - ciliumclusterwidenetworkpolicies.cilium.io
+  - ciliumegressgatewaypolicies.cilium.io
+  - ciliumegressnatpolicies.cilium.io
+  - ciliumendpoints.cilium.io
+  - ciliumendpointslices.cilium.io
+  - ciliumenvoyconfigs.cilium.io
+  - ciliumexternalworkloads.cilium.io
+  - ciliumidentities.cilium.io
+  - ciliumlocalredirectpolicies.cilium.io
+  - ciliumnetworkpolicies.cilium.io
+  - ciliumnodes.cilium.io
 # For cilium-operator running in HA mode.
 #
 # Cilium operator running in HA mode requires the use of ResourceLock for Leader Election

--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -37,12 +37,11 @@ spec:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
-              matchExpressions:
-              - key: io.cilium/app
-                operator: In
-                values:
-                - operator
-            topologyKey: "kubernetes.io/hostname"
+              matchLabels:
+                io.cilium/app: operator
+            topologyKey: kubernetes.io/hostname
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: cilium-operator
         command:

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -164,8 +164,6 @@ global:
   # nodes if worker nodes share a common L2 network segment.
   autoDirectNodeRoutes: false
 
-  bandwidthManager:
-    enabled: false
   localRedirectPolicy:
     enabled: false
 
@@ -285,6 +283,10 @@ global:
   # optimization for nodeport reverse NAT handling.
     lbExternalClusterip: "false"
 
+  # Enable socket-based LB for E/W traffic
+  bpfSocketLB:
+    enabled: false
+
   # bpf-lb-sock-hostns-only skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface.
   # Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).
   bpfSocketLBHostnsOnly:
@@ -313,9 +315,12 @@ global:
     # interface: eth0
 
   # kubeProxyReplacement enables kube-proxy replacement in Cilium BPF datapath
-  kubeProxyReplacement: "disabled"
+  kubeProxyReplacement: "probe"
   # The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable
   kubeProxyReplacementHealthzBindAddress: ""
+
+  # Enable check of service source ranges (currently, only for LoadBalancer)
+  enableSvcSrcRangeCheck: true
 
   # hostServices is the configuration for ClusterIP service handling in host namespace
   hostServices:
@@ -338,6 +343,12 @@ global:
 
     # mode is the mode of NodePort feature
     mode: "hybrid"
+
+    #  Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range)
+    autoProtectPortRange: true
+
+    # Reject application bind(2) requests to service ports in the NodePort range
+    bindProtection: true
 
   # externalIPs is the configuration for ExternalIPs service handling
   externalIPs:
@@ -458,13 +469,10 @@ global:
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: k8s-app
-                operator: In
-                values:
-                  - cilium
-          topologyKey: "kubernetes.io/hostname"
+      - labelSelector:
+          matchLabels:
+            k8s-app: cilium
+        topologyKey: kubernetes.io/hostname
 
   # enables non-drop mode for installed policies. In audit mode
   # packets affected by policies will not be dropped. Policy related


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update cilium to `v1.12.0`. For more information see the [release notes](https://github.com/cilium/cilium/releases/tag/v1.12.0).
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update cilium to `v1.12.0`.
```
