### PR TITLE
Ensure that the kubernetes api server host is always set when running without kube-proxy.

### DIFF
--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -66,6 +66,14 @@ spec:
               key: debug
               name: cilium-config
               optional: true
+        {{- if .Values.global.k8sServiceHost }}
+        - name: KUBERNETES_SERVICE_HOST
+          value: {{ .Values.global.k8sServiceHost | quote }}
+        {{- end }}
+        {{- if .Values.global.k8sServicePort }}
+        - name: KUBERNETES_SERVICE_PORT
+          value: {{ .Values.global.k8sServicePort | quote }}
+        {{- end }}
         image: {{ index .Values.global.images "cilium-operator" }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
 {{- if .Values.global.prometheus.enabled }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Ensure that the kubernetes api server host is always set when running without kube-proxy.

During creation of a cluster there are a few races ongoing. This is especially true if
cilium is running as kube-proxy replacement.
cilium-agent waits for the cilium CRDs to be present in the kubernetes api server, before
performing its ordinary operation, i.e. there is no service routing in case kube-proxy is
disabled and no CNI operations will succeed.
cilium-operator is responsible for adding the CRDs on startup. However, unless the kubernetes
service host is specified, it will fall back on the in cluster name of the kubernetes api
server, i.e. kubernetes.default.svc.cluster.local. Unfortunately, this might not be
resolvable as cilium-agent might still wait on cilium-operator to create the CRDs. This
can lead to a vicious cycle and a hanging cluster creation.
Another contender, which might break the deadlock in some situations, can be the
apiserver-proxy-webhook, which can add the environment variable KUBERNETES_SERVICE_HOST
to containers. However, it is not ensured and actually not too likely that it is
ready before the cilium-operator pod is created.
To resolve this potential deadlock, this change ensures that the kubernetes api server
host is set for the cilium-operator when kube-proxy is disabled. The api server address
is taken from the shoot status, where the external address is utilized. Specific settings
in the network config can override this default.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Ensure that the kubernetes api server host is always set when running cilium without kube-proxy.
```
