### PR TITLE
Fix pod security policy for cilium 1.12 so that it works even if allowPrivilegedContainers is set to false.

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/podsecuritypolicy.yaml
+++ b/charts/internal/cilium/charts/agent/templates/podsecuritypolicy.yaml
@@ -7,8 +7,20 @@ spec:
   privileged: true
   allowPrivilegeEscalation: true
   allowedCapabilities:
+  - CHOWN
+  - KILL
   - NET_ADMIN
+  - NET_RAW
+  - IPC_LOCK
   - SYS_MODULE
+  - SYS_ADMIN
+  - SYS_RESOURCE
+  - DAC_OVERRIDE
+  - FOWNER
+  - SETGID
+  - SETUID
+  - SYS_CHROOT
+  - SYS_PTRACE
   volumes:
   - 'configMap'
   - 'emptyDir'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix pod security policy for cilium 1.12 so that it works even if allowPrivilegedContainers is set to false.

With cilium 1.12, almost all containers of cilium are no longer running as privileged containers,
but specify their required capabilities instead. (The only exception being our kube-proxy cleanup
container.) Unfortunately, the corresponding adaption of the pod security policy was forgotten.
This change updates the pod security policy accordingly so that cilium can run again with
allowPrivilegedContainers=false.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Networking provider cilium works again with allowPrivilegedContainers=false.
```
