### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -529,6 +529,10 @@ spec:
 {{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}
       priorityClassName: system-node-critical
 {{- end }}
+      securityContext:
+        fsGroup: 1
+        supplementalGroups:
+        - 1
       serviceAccount: "cilium"
       serviceAccountName: "cilium"
       terminationGracePeriodSeconds: 1

--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -42,6 +42,14 @@ spec:
             topologyKey: kubernetes.io/hostname
       nodeSelector:
         kubernetes.io/os: linux
+      securityContext:
+        fsGroup: 1
+        supplementalGroups:
+        - 1
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
       containers:
       - name: cilium-operator
         command:

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -169,8 +169,8 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 		return requirementsConfig, globalConfig, nil
 	}
 
-	// check if PSPs are enabled
-	if config.PSPEnabled != nil && globalConfig.Psp.Enabled {
+	// do not overwrite if it's set to false before, otherwise use the value from the config
+	if globalConfig.Psp.Enabled && config.PSPEnabled != nil {
 		globalConfig.Psp.Enabled = *config.PSPEnabled
 	}
 

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -160,12 +160,17 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 		globalConfig.LocalRedirectPolicy.Enabled = true
 	}
 
+	// disable PSPs if it's disabled in the shoot
+	if helper.IsPSPDisabled(cluster.Shoot) {
+		globalConfig.Psp.Enabled = false
+	}
+
 	if config == nil {
 		return requirementsConfig, globalConfig, nil
 	}
 
 	// check if PSPs are enabled
-	if config.PSPEnabled != nil {
+	if config.PSPEnabled != nil && globalConfig.Psp.Enabled {
 		globalConfig.Psp.Enabled = *config.PSPEnabled
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area open-source
/kind enhancement

**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR adapts the mutating fields of the existing PSPs in the PodSpec. 
- Stop deploying PSPs if the plugin is disabled in the Shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Please make sure you're running gardener@v1.52 or above before upgrading to this version.
```
