### PR TITLE
Fix mutating web hook for node-local-dns to work with non-default ports.

### DIFF
--- a/pkg/webhook/shoot/node_local_dns.go
+++ b/pkg/webhook/shoot/node_local_dns.go
@@ -29,8 +29,8 @@ func (m *mutator) mutateNodeLocalDNSConfigMap(ctx context.Context, configmap *co
 
 	re1 := regexp.MustCompile(`bind.*`)
 	configmap.Data["Corefile"] = re1.ReplaceAllString(configmap.Data["Corefile"], "bind 0.0.0.0")
-	re2 := regexp.MustCompile(`health.*`)
-	configmap.Data["Corefile"] = re2.ReplaceAllString(configmap.Data["Corefile"], "health")
+	re2 := regexp.MustCompile(`health.*(:[0-9]+)`)
+	configmap.Data["Corefile"] = re2.ReplaceAllString(configmap.Data["Corefile"], "health $1")
 
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix mutating web hook for node-local-dns to work with non-default ports.

In case a non-default port, i.e. not port 8080, was used the specification
of the liveness probe and the exposed health check port may not fit after
the mutating web hook for node-local-dns has been applied. This should be
fixed now for the standard case.
(Port 8080 was not a good choice for a host port and therefore it was
changed.)

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
With https://github.com/gardener/gardener/pull/6477 the default health check port was changed. Hence, the port needs to be kept by the mutating web hook.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Cilium works again with node-local-dns after change of default health check port to 8099.
```
