### PR TITLE
Do not run cilium/cilium-kube-proxy-clean-up in privileged mode

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -504,7 +504,6 @@ spec:
           capabilities:
             add:
             - NET_ADMIN
-          privileged: true
 {{- else }}
       - command:
         {{- if semverCompare "< 1.17" .Capabilities.KubeVersion.GitVersion }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
According to my testing the `cilium-kube-proxy-clean-up` init container of `cilium` can run with the `NET_ADMIN` capability added and does not need to run in privileged mode.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-security/standard-compliance/issues/3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The cilium/cilium-kube-proxy-clean-up init container no longer runs in privileged mode.
```
