### PR TITLE
Clean up the `kube-proxy-clean-up` init container

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -35,11 +35,3 @@ images:
     sourceRepository: github.com/cilium/certgen
     repository: quay.io/cilium/certgen
     tag: v0.1.8
-  - name: kube-proxy
-    sourceRepository: github.com/kubernetes/kubernetes
-    repository: k8s.gcr.io/hyperkube
-    targetVersion: "< 1.17"
-  - name: kube-proxy
-    sourceRepository: github.com/kubernetes/kubernetes
-    repository: k8s.gcr.io/kube-proxy
-    targetVersion: ">= 1.17"

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -488,11 +488,10 @@ spec:
           {{- toYaml .Values.initResources | trim | nindent 10 }}
 {{- if eq .Values.global.kubeProxyReplacement "strict" }}
       # Clean up kube-proxy iptable rules in case cilium is running as kube-proxy replacement
-{{- if not (eq .Values.kubeProxyCleanup "kube-proxy") }}
       - command:
         - bash
         - -c
-        # Recommended way to clean up according to cilium docs (https://docs.cilium.io/en/latest/gettingstarted/kubeproxy-free/)
+        # Recommended way to clean up according to cilium docs (https://docs.cilium.io/en/v1.12/gettingstarted/kubeproxy-free/)
         #- "iptables-restore <(iptables-save | grep -v KUBE)"
         # Unfortunately, the above is not directly working due to etc/alternatives issue with cilium container image
         # Therefore, we use the equivalent below, which adds also log output
@@ -505,25 +504,6 @@ spec:
             add:
             - NET_ADMIN
           privileged: true
-{{- else }}
-      - command:
-        {{- if semverCompare "< 1.17" .Capabilities.KubeVersion.GitVersion }}
-        - /hyperkube
-        - kube-proxy
-        {{- else }}
-        - /usr/local/bin/kube-proxy
-        {{- end }}
-        - --cleanup
-        - --v=2
-        image: {{ index .Values.global.images "kube-proxy" }}
-        imagePullPolicy: {{ .Values.global.pullPolicy }}
-        name: kube-proxy-clean-up
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-          privileged: true
-{{- end }}
 {{- end }}
       restartPolicy: Always
 {{- if and (eq .Release.Namespace "kube-system") (or (gt .Capabilities.KubeVersion.Minor "10") (gt .Capabilities.KubeVersion.Major "1"))}}

--- a/charts/internal/cilium/charts/agent/values.yaml
+++ b/charts/internal/cilium/charts/agent/values.yaml
@@ -21,6 +21,3 @@ initResources:
   requests:
     cpu: "100m"
     memory: "100Mi"
-
-# Specifies whether to use the approach documented by cilium or kube-proxy to cleanup the iptables from kube-proxy
-kubeProxyCleanup: cilium-documentation

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -491,5 +491,3 @@ global:
     hubble-ui: "image-repository:image-tag"
     hubble-ui-backend: "image-repository:image-tag"
     certgen: "image-repository:image-tag"
-
-    kube-proxy: "image-repository:image-tag"

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -135,7 +135,6 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 	// Also need to configure KubeProxy
 	if cluster.Shoot.Spec.Kubernetes.KubeProxy != nil && cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled != nil && !*cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled {
 		globalConfig.KubeProxyReplacement = ciliumv1alpha1.Strict
-		globalConfig.Images[cilium.KubeProxyImageName] = imagevector.CiliumKubeProxyImage(cluster.Shoot.Spec.Kubernetes.Version)
 
 		if config != nil && config.KubeProxy != nil && config.KubeProxy.ServiceHost != nil && config.KubeProxy.ServicePort != nil {
 			globalConfig.K8sServiceHost = *config.KubeProxy.ServiceHost

--- a/pkg/cilium/types.go
+++ b/pkg/cilium/types.go
@@ -41,9 +41,6 @@ const (
 	// CertGenImageName defines certificate generation image name.
 	CertGenImageName = "certgen"
 
-	// KubeProxyImageName defines the kube-proxy image name.
-	KubeProxyImageName = "kube-proxy"
-
 	// MonitoringChartName
 	MonitoringName = "cilium-monitoring-config"
 

--- a/pkg/imagevector/image_finders.go
+++ b/pkg/imagevector/image_finders.go
@@ -56,8 +56,3 @@ func CiliumHubbleUIBackendImage() string {
 func CiliumCertGenImage() string {
 	return findImage(cilium.CertGenImageName)
 }
-
-// CiliumKubeProxyImage returns the kube-proxy image.
-func CiliumKubeProxyImage(kubernetesVersion string) string {
-	return findImage(cilium.KubeProxyImageName, imagevector.RuntimeVersion(kubernetesVersion), imagevector.TargetVersion(kubernetesVersion))
-}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
See the motivation for this PR in 122.

**Which issue(s) this PR fixes**:
Fixes #122

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
