### PR TITLE
Remove support for kubernetes < 1.17 for kube-proxy.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -37,9 +37,4 @@ images:
     tag: v0.1.8
   - name: kube-proxy
     sourceRepository: github.com/kubernetes/kubernetes
-    repository: registry.k8s.io/hyperkube
-    targetVersion: "< 1.17"
-  - name: kube-proxy
-    sourceRepository: github.com/kubernetes/kubernetes
     repository: registry.k8s.io/kube-proxy
-    targetVersion: ">= 1.17"

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -506,12 +506,7 @@ spec:
             - NET_ADMIN
 {{- else }}
       - command:
-        {{- if semverCompare "< 1.17" .Capabilities.KubeVersion.GitVersion }}
-        - /hyperkube
-        - kube-proxy
-        {{- else }}
         - /usr/local/bin/kube-proxy
-        {{- end }}
         - --cleanup
         - --v=2
         image: {{ index .Values.global.images "kube-proxy" }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind technical-debt

**What this PR does / why we need it**:
Remove support for kubernetes < 1.17 for kube-proxy.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Kubernetes < 1.17 has long run out of community support. There is no need to have support in this extension for it.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Removed support for kubernetes < 1.17 from cilium networking provider.
```
