### PR TITLE
Improve kubernetes conformance per default by using portmap cni binary.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -38,3 +38,7 @@ images:
   - name: kube-proxy
     sourceRepository: github.com/kubernetes/kubernetes
     repository: registry.k8s.io/kube-proxy
+  - name: portmap-copier
+    sourceRepository: github.com/gardener/portmap-copier
+    repository: eu.gcr.io/gardener-project/gardener/portmap-copier
+    tag: v0.1.0

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -315,6 +315,25 @@ spec:
           capabilities:
             drop:
               - ALL
+{{- if eq .Values.global.cni.chainingMode "portmap" }}
+      # Copy portmap binary to cni folder.
+      - name: copy-portmap-binary
+        image: {{ index .Values.global.images "portmap-copier" }}
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: cni-path
+          mountPath: /host
+        securityContext:
+          seLinuxOptions:
+            level: 's0'
+            # Running with spc_t since we have removed the privileged mode.
+            # Users can change it to a different type as long as they have the
+            # type available on the system.
+            type: 'spc_t'
+          capabilities:
+            drop:
+              - ALL
+{{- end }}
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -184,7 +184,7 @@ global:
     #  - generic-veth
     #  - aws-cni
     #  - portmap
-    chainingMode: none
+    chainingMode: portmap
 
     # customConf skips writing of the CNI configuration. This can be used if
     # writing of the CNI configuration is performed by external automation.
@@ -493,3 +493,5 @@ global:
     certgen: "image-repository:image-tag"
 
     kube-proxy: "image-repository:image-tag"
+
+    portmap-copier: "image-repository:image-tag"

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -88,6 +88,8 @@ var defaultGlobalConfig = globalConfig{
 		cilium.HubbleUIImageName:        imagevector.CiliumHubbleUIImage(),
 		cilium.HubbleUIBackendImageName: imagevector.CiliumHubbleUIBackendImage(),
 		cilium.CertGenImageName:         imagevector.CiliumCertGenImage(),
+
+		cilium.PortmapCopierImageName: imagevector.PortmapCopierImage(),
 	},
 	PodCIDR: "",
 	BPFSocketLBHostnsOnly: bpfSocketLBHostnsOnly{

--- a/pkg/cilium/types.go
+++ b/pkg/cilium/types.go
@@ -44,6 +44,9 @@ const (
 	// KubeProxyImageName defines the kube-proxy image name.
 	KubeProxyImageName = "kube-proxy"
 
+	// PortmapCopierImageName defines the portmap-copier image name.
+	PortmapCopierImageName = "portmap-copier"
+
 	// MonitoringChartName
 	MonitoringName = "cilium-monitoring-config"
 

--- a/pkg/imagevector/image_finders.go
+++ b/pkg/imagevector/image_finders.go
@@ -61,3 +61,8 @@ func CiliumCertGenImage() string {
 func CiliumKubeProxyImage(kubernetesVersion string) string {
 	return findImage(cilium.KubeProxyImageName, imagevector.RuntimeVersion(kubernetesVersion), imagevector.TargetVersion(kubernetesVersion))
 }
+
+// PortmapCopierImage returns the portmap copier image.
+func PortmapCopierImage() string {
+	return findImage(cilium.PortmapCopierImageName)
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Improve kubernetes conformance per default by using portmap cni binary.

Kubernetes conformance tests fail if cilium's native host port/ip implementation
is used. Therefore, this change switches to using portmap cni binary per default.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Kubernetes conform hostPort/hostIP handling with cilium clusters.
```
