### PR TITLE
update cilium to v1.12.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,15 +2,15 @@ images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.12.0
+    tag: v1.12.3
   - name: cilium-preflight
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.12.0
+    tag: v1.12.3
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/operator
-    tag: v1.12.0
+    tag: v1.12.3
   - name: cilium-etcd-operator
     sourceRepository: github.com/cilium/cilium
     repository: docker.io/cilium/cilium-etcd-operator
@@ -30,7 +30,7 @@ images:
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-relay
-    tag: v1.12.0
+    tag: v1.12.3
   - name: certgen
     sourceRepository: github.com/cilium/certgen
     repository: quay.io/cilium/certgen

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -206,6 +206,7 @@ spec:
               - SETUID
             drop:
               - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         # Unprivileged containers need to mount /proc/sys/net from the host
         # to have write access
@@ -361,6 +362,7 @@ spec:
             mountPath: /hostproc
           - name: cni-path
             mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           seLinuxOptions:
             level: 's0'
@@ -400,6 +402,7 @@ spec:
           mountPath: /hostproc
         - name: cni-path
           mountPath: /hostbin
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           seLinuxOptions:
             level: 's0'
@@ -428,6 +431,7 @@ spec:
         - /bin/bash
         - -c
         - --
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           privileged: true
         volumeMounts:
@@ -461,6 +465,7 @@ spec:
               optional: true
         image: {{ index .Values.global.images "cilium-agent" }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
           seLinuxOptions:
             level: 's0'

--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -449,9 +449,7 @@ data:
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
 {{- end}}
-{{- if .Values.global.kubeProxyReplacementHealthzBindAddress }}
-kube-proxy-replacement-healthz-bind-address: "{{ .Values.global.kubeProxyReplacementHealthzBindAddress }}"
-{{- end}}
+
 {{- if .Values.global.hostServices }}
 {{- if .Values.global.hostServices.enabled }}
   enable-host-reachable-services: {{ .Values.global.hostServices.enabled | quote }}

--- a/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
           - name: tls
             mountPath: /var/lib/hubble-relay/tls
             readOnly: true
+          terminationMessagePolicy: FallbackToLogsOnError
       restartPolicy: Always
       serviceAccountName: hubble-relay
       {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}

--- a/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
             requests:
               cpu: 100m
               memory: 64Mi
+          terminationMessagePolicy: FallbackToLogsOnError
         - name: backend
           image: {{ index .Values.global.images "hubble-ui-backend" }}
           imagePullPolicy: {{ .Values.global.pullPolicy }}
@@ -59,6 +60,7 @@ spec:
           ports:
             - name: grpc
               containerPort: 8090
+          terminationMessagePolicy: FallbackToLogsOnError
           resources:
             limits:
               cpu: 1000m

--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -131,6 +131,7 @@ spec:
         resources:
           {{- toYaml .Values.resources | trim | nindent 10 }}
 {{- end }}
+        terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
 {{- if .Values.global.etcd.managed }}
       # In managed etcd mode, Cilium must be able to resolve the DNS name of

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -323,9 +323,7 @@ global:
     # interface: eth0
 
   # kubeProxyReplacement enables kube-proxy replacement in Cilium BPF datapath
-  kubeProxyReplacement: "probe"
-  # The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable
-  kubeProxyReplacementHealthzBindAddress: ""
+  kubeProxyReplacement: "disabled"
 
   # Enable check of service source ranges (currently, only for LoadBalancer)
   enableSvcSrcRangeCheck: true

--- a/pkg/apis/cilium/types_network.go
+++ b/pkg/apis/cilium/types_network.go
@@ -64,6 +64,8 @@ const (
 	Probe KubeProxyReplacementMode = "probe"
 	// Partial defines the partial kube-proxy replacement mode
 	Partial KubeProxyReplacementMode = "partial"
+	// Disabled defines the disabled kube-proxy replacement mode
+	KubeProxyReplacementDisabled KubeProxyReplacementMode = "disabled"
 )
 
 // NodePortMode defines how NodePort services are enabled.

--- a/pkg/apis/cilium/v1alpha1/types_network.go
+++ b/pkg/apis/cilium/v1alpha1/types_network.go
@@ -64,6 +64,8 @@ const (
 	Probe KubeProxyReplacementMode = "probe"
 	// Partial defines the partial kube-proxy replacement mode
 	Partial KubeProxyReplacementMode = "partial"
+	// Disabled defines the disabled kube-proxy replacement mode
+	KubeProxyReplacementDisabled KubeProxyReplacementMode = "disabled"
 )
 
 // NodePortMode defines how NodePort services are enabled.

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -47,7 +47,7 @@ var defaultCiliumConfig = requirementsConfig{
 var defaultGlobalConfig = globalConfig{
 	IdentityAllocationMode: ciliumv1alpha1.CRD,
 	Tunnel:                 ciliumv1alpha1.VXLan,
-	KubeProxyReplacement:   ciliumv1alpha1.Probe,
+	KubeProxyReplacement:   ciliumv1alpha1.KubeProxyReplacementDisabled,
 	Etcd: etcd{
 		Enabled: false,
 		Managed: false,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update cilium to `v1.12.3`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update cilium to `v1.12.3`.
```
