### PR TITLE
switch default ipam to kubernetes and use bpf masquerading

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -336,6 +336,7 @@ data:
 
   enable-ipv4-masquerade: {{ .Values.global.enableIpv4Masquerade | quote }}
   enable-ipv6-masquerade: {{ .Values.global.enableIpv6Masquerade | quote }}
+  enable-bpf-masquerade:  {{ .Values.global.enableBPFMasquerade | quote }}
 
   enable-xt-socket-fallback: {{ .Values.global.enableXTSocketFallback | quote }}
   install-iptables-rules: {{ .Values.global.installIptablesRules | quote }}
@@ -444,7 +445,6 @@ data:
     {{ fail "kubeProxyReplacement must be set to 'strict' in order to enable egressGateway" }}
   {{- end}}
   enable-ipv4-egress-gateway: "true"
-  enable-bpf-masquerade: "true"
 {{- end}}
 {{- if .Values.global.kubeProxyReplacement }}
   kube-proxy-replacement:  {{ .Values.global.kubeProxyReplacement | quote }}
@@ -592,16 +592,25 @@ data:
   # A space separated list of iptables chains to disable when installing feeder rules.
   disable-iptables-feeder-rules: {{ .Values.disableIptablesFeederRules | join " " | quote }}
 {{- end }}
-  ipam: "cluster-pool"
-{{- if .Values.global.ipv4.enabled }}
+  ipam: {{ .Values.global.ipam.mode }}
+{{- if (eq .Values.global.ipam.mode "kubernetes" )}}
+  {{- if .Values.global.ipv4.enabled }}
+  k8s-require-ipv4-pod-cidr: "true"
+  {{- end }}
+  {{- if .Values.global.ipv6.enabled }}
+  k8s-require-ipv6-pod-cidr: "true"
+  {{- end }}
+{{- end }}
+{{- if (eq .Values.global.ipam.mode "cluster-pool") }}
+  {{- if .Values.global.ipv4.enabled }}
   cluster-pool-ipv4-cidr: {{ .Values.global.podCIDR | quote }}
   cluster-pool-ipv4-mask-size: {{ .Values.global.ipam.operator.clusterPoolIPv4MaskSize | quote }}
-{{- end }}
-{{- if .Values.global.ipv6.enabled }}
+  {{- end }}
+  {{- if .Values.global.ipv6.enabled }}
   cluster-pool-ipv6-cidr: {{ .Values.global.ipam.operator.clusterPoolIPv6PodCIDR | quote }}
   cluster-pool-ipv6-mask-size: {{ .Values.global.ipam.operator.clusterPoolIPv6MaskSize | quote }}
+  {{- end }}
 {{- end }}
-
 {{- if hasKey .Values "enableCnpStatusUpdates" }}
   disable-cnp-status-updates: {{ (not .Values.enableCnpStatusUpdates) | quote }}
 {{- else if (eq $defaultEnableCnpStatusUpdates "false") }}

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -156,10 +156,11 @@ global:
   # or in a chained CNI setup.
   installNoConntrackIptablesRules: false
 
-  # masquerade enables masquerading of traffic leaving the ndoe for
+  # masquerade enables masquerading of traffic leaving the node for
   # destinations outside of the cluster.
   enableIpv4Masquerade: true
   enableIpv6Masquerade: true
+  enableBPFMasquerade: true
 
   # ipMasqAgent enables and controls BPF ip-masq-agent
   ipMasqAgent:
@@ -457,6 +458,7 @@ global:
     enabled: true
 
   ipam:
+    mode: "kubernetes"
     operator:
       clusterPoolIPv4PodCIDR: "10.0.0.0/8"
       clusterPoolIPv4MaskSize: 24

--- a/pkg/charts/config.go
+++ b/pkg/charts/config.go
@@ -39,6 +39,7 @@ type globalConfig struct {
 	MTU                    int                                     `json:"mtu"`
 	Devices                []string                                `json:"devices"`
 	BPF                    bpf                                     `json:"bpf"`
+	IPAM                   ipam                                    `json:"ipam"`
 }
 
 // etcd related configuration for cilium
@@ -147,4 +148,8 @@ type egressGateway struct {
 
 type bpf struct {
 	LoadBalancingMode ciliumv1alpha1.LoadBalancingMode `json:"lbMode"`
+}
+
+type ipam struct {
+	Mode string `json:"mode"`
 }

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -108,6 +108,9 @@ var defaultGlobalConfig = globalConfig{
 	BPF: bpf{
 		LoadBalancingMode: v1alpha1.SNAT,
 	},
+	IPAM: ipam{
+		Mode: "kubernetes",
+	},
 }
 
 func newGlobalConfig() globalConfig {
@@ -119,8 +122,8 @@ func newRequirementsConfig() requirementsConfig {
 }
 
 // ComputeCiliumChartValues computes the values for the cilium chart.
-func ComputeCiliumChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) (*ciliumConfig, error) {
-	requirementsConfig, globalConfig, err := generateChartValues(config, network, cluster)
+func ComputeCiliumChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster, ipamMode string) (*ciliumConfig, error) {
+	requirementsConfig, globalConfig, err := generateChartValues(config, network, cluster, ipamMode)
 	if err != nil {
 		return nil, fmt.Errorf("error when generating config values %w", err)
 	}
@@ -131,7 +134,7 @@ func ComputeCiliumChartValues(config *ciliumv1alpha1.NetworkConfig, network *ext
 	}, nil
 }
 
-func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) (requirementsConfig, globalConfig, error) {
+func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster, ipamMode string) (requirementsConfig, globalConfig, error) {
 	var (
 		requirementsConfig = newRequirementsConfig()
 		globalConfig       = newGlobalConfig()
@@ -245,6 +248,8 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 		}
 		globalConfig.IPv4NativeRoutingCIDR = *cluster.Shoot.Spec.Networking.Nodes
 	}
+
+	globalConfig.IPAM.Mode = ipamMode
 
 	return requirementsConfig, globalConfig, nil
 }

--- a/pkg/charts/values.go
+++ b/pkg/charts/values.go
@@ -28,8 +28,8 @@ import (
 const CiliumConfigKey = "config.yaml"
 
 // RenderCiliumChart renders the cilium chart with the given values.
-func RenderCiliumChart(renderer chartrenderer.Interface, config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster) ([]byte, error) {
-	values, err := ComputeCiliumChartValues(config, network, cluster)
+func RenderCiliumChart(renderer chartrenderer.Interface, config *ciliumv1alpha1.NetworkConfig, network *extensionsv1alpha1.Network, cluster *extensionscontroller.Cluster, ipamMode string) ([]byte, error) {
+	values, err := ComputeCiliumChartValues(config, network, cluster, ipamMode)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
IPAM mode is changed to `kubernetes` for new shoot cluster. `cluster-pool` mode is preserved for existing ones.
BPF masquerading is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
IPAM mode is changed to `kubernetes` for new shoot cluster. `cluster-pool` mode is preserved for existing ones.
BPF masquerading is enabled.
```
