### PR TITLE
Add missing annotations for seccomp profiles to pod security policies.

### DIFF
--- a/charts/internal/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
@@ -2,6 +2,9 @@
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.hubble-relay
 spec:
   allowPrivilegeEscalation: false
@@ -49,6 +52,9 @@ subjects:
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: gardener.kube-system.hubble-generate-certs
 spec:
   fsGroup:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Add missing annotations for seccomp profiles to pod security policies.

The change introducing seccomp profiles (#129) did not add the annotations for the hubble-relay pod security policies. This results in clusters with allowPrivilegedContainers set to false to fail in case hubble is enabled. This change resolves this issue.

**Which issue(s) this PR fixes**:
Fixes #90

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
PodSecurityPolicy for hubble-relay is now correctly allowing seccomp profiles to be used
```
