### PR TITLE
Use resources.gardener.cloud/delete-on-invalid-update annotation for hubble generate certificate job.

### DIFF
--- a/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
@@ -2,8 +2,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  # Name was changed to successfully update previous job
-  name: hubble-generate-cert
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+  name: hubble-generate-certs
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: hubble-generate-certs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Use resources.gardener.cloud/delete-on-invalid-update annotation for hubble generate certificate job.

Changes in the generate certificate job caused issues as the spec.template of the job is immutable. The gardener resource manager allows to workaround this limitation when a resource is annotated with resources.gardener.cloud/delete-on-invalid-update=true. By setting this annotation, it is possible to properly use a container image overwrite or update the resource on upstream updates.

**Which issue(s) this PR fixes**:
Fixes #49.

**Special notes for your reviewer**:
Renamed the job to the upstream equivalent.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
hubble-generate-certs job can now use image overwrites.
```
