### PR TITLE
Mark cilium as node-critical component

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cilium
   namespace: {{ .Release.Namespace }}
   labels:
+    node.gardener.cloud/critical-component: "true"
     gardener.cloud/role: system-component
     k8s-app: cilium
 spec:
@@ -26,6 +27,7 @@ spec:
         container.apparmor.security.beta.kubernetes.io/mount-cgroup: "unconfined"
         container.apparmor.security.beta.kubernetes.io/apply-sysctl-overwrites: "unconfined"
       labels:
+        node.gardener.cloud/critical-component: "true"
         k8s-app: cilium
     spec:
       containers:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `node.gardener.cloud/critical-component` label to `cilium` DaemonSet introduced in https://github.com/gardener/gardener/pull/7406 

**Which issue(s) this PR fixes**:
Part of  https://github.com/gardener/gardener/issues/7117

**Special notes for your reviewer**:
https://github.com/gardener/gardener/pull/7406 is merged

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`cilium` is marked as a node-critical component. With this, workload pods are only scheduled to a `Node` if it runs a ready `cilium` pod.
```
