### PR TITLE
enforce overlay mode

### DIFF
--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -102,12 +102,13 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 			}
 			networkConfig.IPv4NativeRoutingCIDREnabled = pointer.Bool(false)
 		}
+		// enforce overlay as there are problems with newer versions of gardenlinux and iptables
 		if networkConfig.Overlay != nil && !networkConfig.Overlay.Enabled {
-			networkConfig.TunnelMode = (*ciliumv1alpha1.TunnelMode)(pointer.String(string(ciliumv1alpha1.Disabled)))
-			networkConfig.IPv4NativeRoutingCIDREnabled = pointer.Bool(true)
-			networkConfig.SnatOutOfCluster = &ciliumv1alpha1.SnatOutOfCluster{Enabled: true}
+			networkConfig.TunnelMode = (*ciliumv1alpha1.TunnelMode)(pointer.String(string(ciliumv1alpha1.VXLan)))
+			networkConfig.IPv4NativeRoutingCIDREnabled = pointer.Bool(false)
+			networkConfig.SnatOutOfCluster = &ciliumv1alpha1.SnatOutOfCluster{Enabled: false}
 			if networkConfig.SnatToUpstreamDNS == nil {
-				networkConfig.SnatToUpstreamDNS = &ciliumv1alpha1.SnatToUpstreamDNS{Enabled: true}
+				networkConfig.SnatToUpstreamDNS = &ciliumv1alpha1.SnatToUpstreamDNS{Enabled: false}
 			}
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Enforce overlay mode for now as there are problems with newer versions of gardenlinux which have switched from `iptables-legacy` to `iptalbes-nft`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Overlay mode for cilium shoot clusters is now enforced.
```
