### PR TITLE
Enable operator ha mode only on cluster with nodes > 1

### DIFF
--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
     name: cilium-operator
     app.kubernetes.io/part-of: cilium
     app.kubernetes.io/name: cilium-operator
+    {{- if .Values.global.operatorHighAvailability.enabled }}
     high-availability-config.resources.gardener.cloud/type: controller
+    {{- end }}
 spec:
   # See docs on ServerCapabilities.LeasesResourceLock in file pkg/k8s/version/version.go
   # for more details.

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -113,6 +113,9 @@ global:
     serviceMonitor:
       enabled: false
 
+  operatorHighAvailability:
+    enabled: true
+
   # operatorPrometheus enables
   operatorPrometheus:
     enabled: true

--- a/pkg/charts/config.go
+++ b/pkg/charts/config.go
@@ -16,33 +16,34 @@ type requirementsConfig struct {
 }
 
 type globalConfig struct {
-	Tunnel                 ciliumv1alpha1.TunnelMode               `json:"tunnel"`
-	IdentityAllocationMode ciliumv1alpha1.IdentityAllocationMode   `json:"identityAllocationMode"`
-	KubeProxyReplacement   ciliumv1alpha1.KubeProxyReplacementMode `json:"kubeProxyReplacement"`
-	Etcd                   etcd                                    `json:"etcd"`
-	Ipv4                   ipv4                                    `json:"ipv4"`
-	Ipv6                   ipv6                                    `json:"ipv6"`
-	Debug                  debug                                   `json:"debug"`
-	Prometheus             prometheus                              `json:"prometheus"`
-	OperatorPrometheus     operatorPrometheus                      `json:"operatorPrometheus"`
-	Psp                    psp                                     `json:"psp"`
-	Images                 map[string]string                       `json:"images"`
-	K8sServiceHost         string                                  `json:"k8sServiceHost"`
-	K8sServicePort         int32                                   `json:"k8sServicePort"`
-	NodePort               nodePort                                `json:"nodePort"`
-	PodCIDR                string                                  `json:"podCIDR"`
-	NodeCIDR               string                                  `json:"nodeCIDR"`
-	BPFSocketLBHostnsOnly  bpfSocketLBHostnsOnly                   `json:"bpfSocketLBHostnsOnly"`
-	LocalRedirectPolicy    localRedirectPolicy                     `json:"localRedirectPolicy"`
-	NodeLocalDNS           nodeLocalDNS                            `json:"nodeLocalDNS"`
-	EgressGateway          egressGateway                           `json:"egressGateway"`
-	IPv4NativeRoutingCIDR  string                                  `json:"ipv4NativeRoutingCIDR"`
-	MTU                    int                                     `json:"mtu"`
-	Devices                []string                                `json:"devices"`
-	BPF                    bpf                                     `json:"bpf"`
-	IPAM                   ipam                                    `json:"ipam"`
-	SnatToUpstreamDNS      snatToUpstreamDNS                       `json:"snatToUpstreamDNS"`
-	SnatOutOfCluster       snatOutOfCluster                        `json:"snatOutOfCluster"`
+	Tunnel                   ciliumv1alpha1.TunnelMode               `json:"tunnel"`
+	IdentityAllocationMode   ciliumv1alpha1.IdentityAllocationMode   `json:"identityAllocationMode"`
+	KubeProxyReplacement     ciliumv1alpha1.KubeProxyReplacementMode `json:"kubeProxyReplacement"`
+	Etcd                     etcd                                    `json:"etcd"`
+	Ipv4                     ipv4                                    `json:"ipv4"`
+	Ipv6                     ipv6                                    `json:"ipv6"`
+	Debug                    debug                                   `json:"debug"`
+	Prometheus               prometheus                              `json:"prometheus"`
+	OperatorHighAvailability operatorHighAvailability                `json:"operatorHighAvailability"`
+	OperatorPrometheus       operatorPrometheus                      `json:"operatorPrometheus"`
+	Psp                      psp                                     `json:"psp"`
+	Images                   map[string]string                       `json:"images"`
+	K8sServiceHost           string                                  `json:"k8sServiceHost"`
+	K8sServicePort           int32                                   `json:"k8sServicePort"`
+	NodePort                 nodePort                                `json:"nodePort"`
+	PodCIDR                  string                                  `json:"podCIDR"`
+	NodeCIDR                 string                                  `json:"nodeCIDR"`
+	BPFSocketLBHostnsOnly    bpfSocketLBHostnsOnly                   `json:"bpfSocketLBHostnsOnly"`
+	LocalRedirectPolicy      localRedirectPolicy                     `json:"localRedirectPolicy"`
+	NodeLocalDNS             nodeLocalDNS                            `json:"nodeLocalDNS"`
+	EgressGateway            egressGateway                           `json:"egressGateway"`
+	IPv4NativeRoutingCIDR    string                                  `json:"ipv4NativeRoutingCIDR"`
+	MTU                      int                                     `json:"mtu"`
+	Devices                  []string                                `json:"devices"`
+	BPF                      bpf                                     `json:"bpf"`
+	IPAM                     ipam                                    `json:"ipam"`
+	SnatToUpstreamDNS        snatToUpstreamDNS                       `json:"snatToUpstreamDNS"`
+	SnatOutOfCluster         snatOutOfCluster                        `json:"snatOutOfCluster"`
 }
 
 // etcd related configuration for cilium
@@ -62,6 +63,10 @@ type prometheus struct {
 }
 
 type serviceMonitor struct {
+	Enabled bool `json:"enabled"`
+}
+
+type operatorHighAvailability struct {
 	Enabled bool `json:"enabled"`
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/area high-availability
/kind bug

**What this PR does / why we need it**:
Please see issue https://github.com/gardener/gardener-extension-networking-cilium/issues/165

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-networking-cilium/issues/165

**Special notes for your reviewer**:
I don't know if this is the right way to do this.
I just thought I might try :)

**Release note**:
```bugfix operator
The cilium operator now only runs with multiple replicas if the shoot cluster has multiple nodes
```
