### PR TITLE
Make the `gardener-extension-admission-cilium` Service topology-aware

### DIFF
--- a/charts/gardener-extension-admission-cilium/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-cilium/charts/runtime/templates/service.yaml
@@ -3,8 +3,15 @@ kind: Service
 metadata:
   name: {{ include "name" . }}
   namespace: {{ .Release.Namespace }}
+  {{- if .Values.global.service.topologyAwareRouting.enabled }}
+  annotations:
+    service.kubernetes.io/topology-aware-hints: "auto"
+  {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
+    {{- if .Values.global.service.topologyAwareRouting.enabled }}
+    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
+    {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/gardener-extension-admission-cilium/values.yaml
+++ b/charts/gardener-extension-admission-cilium/values.yaml
@@ -44,3 +44,6 @@ global:
     enabled: false
     expirationSeconds: 43200
     audience: ""
+  service:
+    topologyAwareRouting:
+      enabled: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area networking
/kind enhancement

**What this PR does / why we need it**:
The following Service is adapted to be topology-aware:
- `gardener-extension-admission-cilium` - the Service is consumed by `gardener-apiserver` for the webhook communication

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6718

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener-extension-admission-cilium` Service in the `gardener-extension-admission-cilium` chart can now be configured to be topology-aware.
```
