### PR TITLE
enable hostport 4244 independently of prometheus

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/podsecuritypolicy.yaml
+++ b/charts/internal/cilium/charts/agent/templates/podsecuritypolicy.yaml
@@ -31,10 +31,10 @@ spec:
   - 'secret'
   - 'downwardAPI'
   - 'hostPath'
-  {{- if .Values.global.prometheus.enabled }}
   hostPorts:
   - min: 4244
     max: 4244
+  {{- if .Values.global.prometheus.enabled }}
   - min: 9090
     max: 9090
   - min: 9091


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
enable hostport 4244 independently of prometheus


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
