### PR TITLE
Add support for TopologyAwareHints (topology-aware traffic routing)

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -464,6 +464,7 @@ data:
 {{- end }}
   node-port-bind-protection: {{ .Values.global.nodePort.bindProtection | quote }}
   enable-auto-protect-node-port-range: {{ .Values.global.nodePort.autoProtectPortRange | quote }}
+  enable-service-topology: {{ .Values.global.loadBalancer.serviceTopology | quote }}
   enable-svc-source-range-check: {{ .Values.global.enableSvcSrcRangeCheck | quote }}
 {{- end }}
 {{- if hasKey .Values "sessionAffinity" }}

--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -326,6 +326,12 @@ global:
     # protocols is the list of protocols to support
     protocols: tcp,udp
 
+  # Configure service load balancing
+  loadBalancer:
+    # serviceTopology enables K8s Topology Aware Hints -based service
+    # endpoints filtering
+    serviceTopology: true
+
   # nodePort is the configuration for NodePort service handling
   nodePort:
     # enabled enables NodePort functionality

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -38,18 +38,17 @@ The `psp` field describes whether `cilium-operator` and `cilium-agent` shall be 
 
 The `tunnel` field describes the encapsulation mode for communication between nodes. Possible values are `vxlan` (default), `geneve` or `disabled`.
 
-The `bpfSocketLBHostnsOnly.enabled` field describes wheter socket LB will be skipped for services when inside a pod namespace (default), in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. This feature is required when using cilium with a service mesh like istio or linkerd.
+The `bpfSocketLBHostnsOnly.enabled` field describes whether socket LB will be skipped for services when inside a pod namespace (default), in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. This feature is required when using cilium with a service mesh like istio or linkerd.
 
-The `egressGateway.enabled` field describes wheter egress gateways are enabled or not (default). To use this feature kube-proxy must be disabled. This can be done with the following configuration in the shoot.yaml file:
-
-```
+The `egressGateway.enabled` field describes whether egress gateways are enabled or not (default). To use this feature kube-proxy must be disabled. This can be done with the following configuration in the Shoot:
+```yaml
 spec:
   kubernetes:
     kubeProxy:
       enabled: false
 ```
 
-The `snatToUpstreamDNS.enabled` field describes wheter the traffic to the upstream dns server should be masqueraded or not (default). This is needed on some infrastructures where traffic to the dns server with the pod CIDR range is blocked.
+The `snatToUpstreamDNS.enabled` field describes whether the traffic to the upstream dns server should be masqueraded or not (default). This is needed on some infrastructures where traffic to the dns server with the pod CIDR range is blocked.
 
 ## Example `Shoot` manifest
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
cilium can run Shoot clusters without kube-proxy. Additionally, according to my testing in local setup, even when kube-proxy is enabled, its [TopologyAwareHints feature](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) didn't work. I had to explicitly enable the corresponding feature on cilium side.
The change that implements the TopologyAwareHints (topology-aware traffic routing) in cilium is https://github.com/cilium/cilium/pull/17929. This PR enables the corresponding setting for Shoots using cilium.
In this way the topology-aware traffic routing feature in gardener (ref https://github.com/gardener/gardener/blob/master/docs/usage/topology_aware_routing.md) can be used in cilium Seed clusters as well. Additionally, any Shoot cluster that wants to benefit from the upstream TopologyAwareHints feature can now do it.
 
**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6718

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The networking-cilium extension does now run cilium with `enable-service-topology: true`. With this it is possible to use the TopologyAwareHints (topology-aware traffic routing) feature in cilium Shoots.
```
