### PR TITLE
increase bpf-policy-map-max to 65536

### DIFF
--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -268,7 +268,7 @@ global:
 
     # bpf-policy-map-max specifies the maximum number of entries in endpoint
     # policy map (per endpoint)
-    policyMapMax: "16384"
+    policyMapMax: "65536"
 
     # bpf-lb-map-max specifies the maximum number of entries in bpf lb service,
     # backend and affinity maps.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
For large clusters the default value ("16384") of bpf-policy-map-max might be to small and result in errors like ```"Unable to update element for cilium_policy_01432 map with file descriptor 243: the map is full"``` thus the value of the bpf-policy-map-max field will be increased to "65536". This change will slightly increase the overall memory consumption of the cilium pods in the magnitude of a few megabytes.

**Which issue(s) this PR fixes**:
Fixes #195

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
bpf-policy-map-max value is increased to 65536.
```
