### PR TITLE
Fix versioning in charts

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/podsecuritypolicy.yaml
+++ b/charts/internal/cilium/charts/agent/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.psp.enabled }}
-apiVersion: {{ include "podsecuritypolicyversion" .}}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:

--- a/charts/internal/cilium/charts/agent/templates/servicemonitor.yaml
+++ b/charts/internal/cilium/charts/agent/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
-apiVersion: {{ include "servicemonitoringversion" .}}
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-agent

--- a/charts/internal/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.psp.enabled }}
-apiVersion: {{ include "podsecuritypolicyversion" .}}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:
@@ -49,7 +49,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 ---
 # hubble-generate-certs
-apiVersion: {{ include "podsecuritypolicyversion" .}}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:

--- a/charts/internal/cilium/charts/operator/templates/podsecuritypolicy.yaml
+++ b/charts/internal/cilium/charts/operator/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.global.psp.enabled }}
-apiVersion: {{ include "podsecuritypolicyversion" .}}
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   annotations:

--- a/charts/internal/cilium/charts/operator/templates/servicemonitor.yaml
+++ b/charts/internal/cilium/charts/operator/templates/servicemonitor.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.global.prometheus.enabled (.Values.global.prometheus.serviceMonitor.enabled) }}
-apiVersion: {{ include "servicemonitoringversion" .}}
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: cilium-operator


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Some charts were missed to be adapted in https://github.com/gardener/gardener-extension-networking-cilium/pull/213/commits/cec9afeda59a8be5eb64974aaff7823a691127c3.
This PR adapts them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue in the charts missing versions for some resources is now fixed.
```
