### PR TITLE
Fix reconciliation of hibernated clusters.

### DIFF
--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -159,6 +159,10 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 }
 
 func getCiliumConfigMap(ctx context.Context, cl client.Client, cluster *extensionscontroller.Cluster) (*corev1.ConfigMap, error) {
+	// Cannot retrieve config map of hibernated clusters => use empty config map instead
+	if extensionscontroller.IsHibernated(cluster) {
+		return &corev1.ConfigMap{}, nil
+	}
 	_, shootClient, err := util.NewClientForShoot(ctx, cl, cluster.ObjectMeta.Name, client.Options{}, extensionsconfig.RESTOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not create shoot client: %w", err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix reconciliation of hibernated clusters.

In the past, the extension library utilized a lazy kubernetes client instantiation. However, this changed recently with gardener v1.80 and its controller-runtime update. Now, the kubernetes client creation will fail if the api-server is not available. In case a shoot cluster is hibernated, the api-server is not available. Hence, the reconciliation will run into a corresponding error. This was handled previously by discarding the error returned from the GET call. Now, we check first if the cluster is hibernated and only create the client if it is not.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Previously, this caused the following error:

```
error during reconciliation: Error reconciling Network: error getting cilium configMap: could not create shoot client: failed to create new DynamicRESTMapper: Get "https://kube-apiserver.shoot--project--shootname.svc/api?timeout=32s": dial tcp 1.2.3.4:443: i/o timeout]
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reconciliation of hibernated cilium clusters now works again.
```
