### PR TITLE
Fix error with iptables-nft.

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -319,7 +319,7 @@ data:
   enable-ipv4-masquerade: {{ .Values.global.enableIpv4Masquerade | quote }}
   enable-ipv6-big-tcp: {{ .Values.global.enableIpv6BigTCP | quote }}
   enable-ipv6-masquerade: {{ .Values.global.enableIpv6Masquerade | quote }}
-{{- if not .Values.global.snatToUpstreamDNS.enabled }}
+{{- if ne .Values.global.tunnel "disabled" }}
   enable-bpf-masquerade:  {{ .Values.global.enableBPFMasquerade | quote }}
 {{- end }}
 

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -274,7 +274,10 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 
 	// check if ipv4 native routing cidr is set
 	if config.IPv4NativeRoutingCIDREnabled != nil && *config.IPv4NativeRoutingCIDREnabled {
-		globalConfig.IPv4NativeRoutingCIDR = "0.0.0.0/0"
+		if cluster.Shoot.Spec.Networking.Pods == nil {
+			return requirementsConfig, globalConfig, fmt.Errorf("pods cidr required for setting ipv4 native routing cidr was not yet set")
+		}
+		globalConfig.IPv4NativeRoutingCIDR = *cluster.Shoot.Spec.Networking.Pods
 	}
 
 	if config.SnatToUpstreamDNS != nil && config.SnatToUpstreamDNS.Enabled {

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -105,10 +105,6 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 		if networkConfig.Overlay != nil && !networkConfig.Overlay.Enabled {
 			networkConfig.TunnelMode = (*ciliumv1alpha1.TunnelMode)(pointer.String(string(ciliumv1alpha1.Disabled)))
 			networkConfig.IPv4NativeRoutingCIDREnabled = pointer.Bool(true)
-			networkConfig.SnatOutOfCluster = &ciliumv1alpha1.SnatOutOfCluster{Enabled: true}
-			if networkConfig.SnatToUpstreamDNS == nil {
-				networkConfig.SnatToUpstreamDNS = &ciliumv1alpha1.SnatToUpstreamDNS{Enabled: true}
-			}
 		}
 	}
 


### PR DESCRIPTION
`IPv4NativeRoutingCIDR = "0.0.0.0/0"` leads to an invalid iptables rule that never matches. In case of iptables-nft this leads to an error. The intention of choosing "0.0.0.0/0" was to have a CIDR that includes both pod and nodes range. However, cilium takes care not to masquerade traffic to node addresses. So it's save to choose the pod range for `IPv4NativeRoutingCIDR`. As a result, the iptables masquerade rules, that are added by the sidecars  are not needed anymore. `SnatOutOfCluster` and `SnatToUpstreamDNS` can be switched off as default.

default nat rules without overlay before the change:
```
Chain CILIUM_POST_nat (1 references)
 pkts bytes target     prot opt in     out     source               destination
  235 22730 MASQUERADE  all  --  *      !cilium_+  100.80.0.0/12        10.181.0.2           /* cilium masquerade non-cluster */
  277 16620 ACCEPT     all  --  *      *       100.80.0.0/24        0.0.0.0/0            match-set cilium_node_set_v4 dst /* exclude traffic to cluster nodes from masquerade */ <In this case destination is an ipset containing all node ips>
  459 27646 MASQUERADE  all  --  *      !cilium_+  100.80.0.0/24       !0.0.0.0/0        /* cilium masquerade non-cluster */  -< This rules is not excepted by iptables-nft !0.0.0.0/0 would never match. 0.0.0.0/0 is configured via IPv4NativeRoutingCIDR>
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xa00/0xe00 /* exclude proxy return traffic from masquerade */
    0     0 SNAT       all  --  *      cilium_host  127.0.0.1            0.0.0.0/0            /* cilium host->cluster from 127.0.0.1 masquerade */ to:100.80.0.101
    0     0 SNAT       all  --  *      cilium_host  0.0.0.0/0            0.0.0.0/0            mark match 0xf00/0xf00 ctstate DNAT /* hairpin traffic that originated from a local pod */ to:100.80.0.101
 3758  278K RETURN     all  --  *      *       100.80.0.0/12        100.80.0.0/12
    0     0 RETURN     all  --  *      *       100.80.0.0/12        10.181.0.0/16
    0     0 MASQUERADE  all  --  *      !cilium_+  100.80.0.0/12        0.0.0.0/0            /* cilium masquerade non-cluster */
```

Default nat rules with this change:
```
Chain CILIUM_POST_nat (1 references)
 pkts bytes target     prot opt in     out     source               destination
  277 16620 ACCEPT     all  --  *      *       100.80.0.0/24        0.0.0.0/0            match-set cilium_node_set_v4 dst /* exclude traffic to cluster nodes from masquerade */ <In this case destination is an ipset containing all node ips. Everything coming from pods going to nodes is not masqueraded>
  459 27646 MASQUERADE  all  --  *      !cilium_+  100.80.0.0/24       !100.80.0.0/12        /* cilium masquerade non-cluster */  < Here we jump to MASQERADE for everything not leaving a cilium interface and not going to a cidr in the pod range. Here we would also jump to masquerade for the DNS IP.>
    0     0 ACCEPT     all  --  *      *       0.0.0.0/0            0.0.0.0/0            mark match 0xa00/0xe00 /* exclude proxy return traffic from masquerade */
    0     0 SNAT       all  --  *      cilium_host  127.0.0.1            0.0.0.0/0            /* cilium host->cluster from 127.0.0.1 masquerade */ to:100.80.0.101
    0     0 SNAT       all  --  *      cilium_host  0.0.0.0/0            0.0.0.0/0            mark match 0xf00/0xf00 ctstate DNAT /* hairpin traffic that originated from a local pod */ to:100.80.0.101
```


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes an error that occurs when running with iptables-nft.
```
