### PR TITLE
Add `apiVersion: v1` to gardener-extension-admission-cilium `ServiceAccount`

### DIFF
--- a/charts/gardener-extension-admission-cilium/charts/runtime/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-admission-cilium/charts/runtime/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "name" . }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
With https://github.com/gardener/gardener-extension-networking-cilium/pull/234  the `apiVersion` field was removed from [`charts/gardener-extension-admission-cilium/charts/runtime/templates/serviceaccount.yaml`](https://github.com/timuthy/gardener-extension-networking-cilium/blob/1f83e49f815486c5130bcefaaaf2ea9ceb7d4092/charts/gardener-extension-admission-cilium/charts/runtime/templates/serviceaccount.yaml).

This causes the following error when using these charts to deploy the admission with the [local gardener setup with extensions](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally_with_extensions.md):
```
[error validating data: apiVersion not set; if you choose to ignore these errors, turn validation off with --validate=false](error: error validating "/var/folders/bh/hg7dql3d335b8bbcfz7t242h0000gn/T/tmp.b0KmJ2olbv/runtime-resources.yaml": error validating data: apiVersion not set; if you choose to ignore these errors, turn validation off with --validate=false)
```

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed a validation error which occurs when deploying the `gardener-extension-admission-cilium` charts because of a missing `apiVersion` field in its `charts/gardener-extension-admission-cilium/charts/runtime/templates/serviceaccount.yaml` file.
```
