### PR TITLE
Fix casing of l7 proxy configuration to enable it by default

### DIFF
--- a/charts/internal/cilium/values.yaml
+++ b/charts/internal/cilium/values.yaml
@@ -459,7 +459,7 @@ global:
     sidecarImageRegex: "cilium/istio_proxy"
 
   # Enables L7 proxy for L7 policy enforcement and visibility
-  l7proxy:
+  l7Proxy:
     enabled: true
 
   ipam:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix casing of l7 proxy configuration to enable it by default.

**Which issue(s) this PR fixes**:
Fixes #257.

**Special notes for your reviewer**:
The usage of this helm option
https://github.com/gardener/gardener-extension-networking-cilium/blob/313bf583be3b6b8ae9c0db4b013ffdc7e6672f5a/charts/internal/cilium/charts/config/templates/configmap.yaml#L313
was using `l7Proxy` while it was introduced with the cilium 1.9.4 update as `l7proxy` in the configuration:
https://github.com/gardener/gardener-extension-networking-cilium/blob/313bf583be3b6b8ae9c0db4b013ffdc7e6672f5a/charts/internal/cilium/values.yaml#L462

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Cilium configuration option `enable-l7-proxy` is now enabled per default.
```
