### PR TITLE
run e2e test cluster without kube-proxy

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 var (
@@ -62,7 +63,7 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 				},
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 				KubeProxy: &gardencorev1beta1.KubeProxyConfig{
-					Mode:    defaultShootCreationFramework().Shoot.Spec.Kubernetes.KubeProxy.Mode,
+					Mode:    ptr.To(gardencorev1beta1.ProxyModeIPTables),
 					Enabled: pointer.Bool(false),
 				},
 			},

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -61,6 +61,10 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 					RegistryBurst:       pointer.Int32(20),
 				},
 				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+				KubeProxy: &gardencorev1beta1.KubeProxyConfig{
+					Mode:    defaultShootCreationFramework().Shoot.Spec.Kubernetes.KubeProxy.Mode,
+					Enabled: pointer.Bool(false),
+				},
 			},
 			Networking: &gardencorev1beta1.Networking{
 				Type:           pointer.String("cilium"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Run e2e test cluster without kube-proxy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
