### PR TITLE
fix: enable-bpf-masquerade when snat values are not enabled

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -323,7 +323,7 @@ data:
   enable-ipv6-masquerade: {{ .Values.global.enableIpv6Masquerade | quote }}
   enable-tcx: "true"
   datapath-mode: "veth"
-{{- if ne .Values.global.tunnel "disabled" }}
+{{- if and (not .Values.global.snatOutOfCluster.enabled) (not .Values.global.snatToUpstreamDNS.enabled ) }}
   enable-bpf-masquerade:  {{ .Values.global.enableBPFMasquerade | quote }}
 {{- end }}
   enable-masquerade-to-route-source: "false"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind TODO

**What this PR does / why we need it**:

Enable bpf-masquerading on direct routing if SNAT masquerades are not enabled.
For more information see the issue.

**Which issue(s) this PR fixes**:
Fixes #349 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use BPF masquerading and therefore BPF host routing in Cilium when using direct routing.
```
