### PR TITLE
Publish separate admission Helm charts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,9 +10,18 @@ gardener-extension-networking-cilium:
         attribute: image.repository
       - ref: ocm-resource:gardener-extension-networking-cilium.tag
         attribute: image.tag
-    - &admission-cilium
-      name: admission-cilium
-      dir: charts/gardener-extension-admission-cilium
+    - &admission-cilium-application
+      name: admission-cilium-application
+      dir: charts/gardener-extension-admission-cilium/application
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-cilium.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-cilium.tag
+        attribute: global.image.tag
+    - &admission-cilium-runtime
+      name: admission-cilium-runtime
+      dir: charts/gardener-extension-admission-cilium/runtime
       registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
       mappings:
       - ref: ocm-resource:gardener-extension-admission-cilium.repository
@@ -79,7 +88,8 @@ gardener-extension-networking-cilium:
         publish:
           helmcharts:
           - *networking-cilium
-          - *admission-cilium
+          - *admission-cilium-application
+          - *admission-cilium-runtime
     pull-request:
       traits:
         pull-request: ~
@@ -88,7 +98,8 @@ gardener-extension-networking-cilium:
         publish:
           helmcharts:
           - *networking-cilium
-          - *admission-cilium
+          - *admission-cilium-application
+          - *admission-cilium-runtime
     release:
       traits:
         version:
@@ -116,5 +127,7 @@ gardener-extension-networking-cilium:
           helmcharts:
           - <<: *networking-cilium
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
-          - <<: *admission-cilium
+          - <<: *admission-cilium-application
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *admission-cilium-runtime
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Admission Helm charts have to be published as separate charts for application and runtime.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
