### PR TITLE
Allow running without network config

### DIFF
--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -211,6 +211,10 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 		}
 	}
 
+	// check if IPv4 is enabled
+	if config.IPv4 != nil {
+		globalConfig.Ipv4.Enabled = config.IPv4.Enabled
+	}
 	// check if IPv6 is enabled
 	if config.IPv6 != nil {
 		globalConfig.Ipv6.Enabled = config.IPv6.Enabled
@@ -259,18 +263,6 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 		globalConfig.BPF = bpf{
 			LoadBalancingMode: *config.LoadBalancingMode,
 		}
-	}
-
-	if config.IPv4.Enabled {
-		globalConfig.Ipv4.Enabled = true
-	} else {
-		globalConfig.Ipv4.Enabled = false
-	}
-
-	if config.IPv6.Enabled {
-		globalConfig.Ipv6.Enabled = true
-	} else {
-		globalConfig.Ipv6.Enabled = false
 	}
 
 	// check if ipv4 native routing cidr is set


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

Fix nil dereference in [IPv6 support](https://github.com/gardener/gardener-extension-networking-cilium/pull/421) in case no network config was specified.

In addition to that, the code is simplified and redundancy has been removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
