### PR TITLE
Re-enable "test: access kube-apiserver through apiserver-proxy"

### DIFF
--- a/test/templates/network-test.yaml.tpl
+++ b/test/templates/network-test.yaml.tpl
@@ -130,10 +130,21 @@ data:
             echo "$(date): $ip - succeeded"
         done
     }
+
+    function curl_kubeapi_through_proxy() {
+        ip=$(kubectl get endpoints -n default kubernetes -o jsonpath='{.subsets[*].addresses[*].ip}')
+        curl -v --max-time 5 --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --resolve kubernetes:443:${ip} https://kubernetes:443
+        if [ $? -ne 0 ]
+        then
+            echo "ERROR: curl to kubernetes api ${ip} failed"
+            exit 1
+        fi
+      }
     
     while true
     do 
         sleep 15
         ping_ips "host-network"
         ping_ips "pod-network"
+        curl_kubeapi_through_proxy
     done


### PR DESCRIPTION
Merge after update to gardener release 1.113.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind test

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other test
test: access kube-apiserver through apiserver-proxy
```
