### PR TITLE
Cilium deny all netpol prepare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh "" $(REPO_ROOT)/VERSION "$(EXTENSION_PREFIX)")"
 LEADER_ELECTION             := false
 IGNORE_OPERATION_ANNOTATION := true
+ARCH                		?= amd64
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -66,8 +67,8 @@ docker-login:
 
 .PHONY: docker-images
 docker-images:
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION)           -t $(IMAGE_PREFIX)/$(NAME):latest           -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME)           .
-	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(NAME):$(VERSION)           -t $(IMAGE_PREFIX)/$(NAME):latest           -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME)           .
+	@docker build --platform=linux/$(ARCH) --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #

--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -34,6 +34,9 @@ spec:
         k8s-app: cilium
         app.kubernetes.io/name: cilium-agent
         app.kubernetes.io/part-of: cilium
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       containers:
 {{- if .Values.global.sleepAfterInit }}

--- a/charts/internal/cilium/charts/envoy/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/envoy/templates/daemonset.yaml
@@ -29,6 +29,9 @@ spec:
         k8s-app: cilium-envoy
         app.kubernetes.io/name: cilium-envoy
         app.kubernetes.io/part-of: cilium
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       containers:
       - name: cilium-envoy

--- a/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/deployment.yaml
@@ -18,6 +18,9 @@ spec:
         k8s-app: {{ .Chart.Name }}
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/part-of: cilium
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       securityContext:
         fsGroup: 65532

--- a/charts/internal/cilium/charts/hubble-relay/templates/network-policy.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/network-policy.yaml
@@ -1,0 +1,52 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gardener.cloud--allow-hubble-relay-from-hubble-ui
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s-app: hubble-ui
+      toPorts:
+        - ports:
+            - port: "4245"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gardener.cloud--allow-hubble-ui-to-hubble-relay
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-ui
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s-app: hubble-relay
+      toPorts:
+        - ports:
+            - port: "4245"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: gardener.cloud--allow-hubble-relay-to-peers
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s-app: hubble-relay
+  egress:
+    - toEntities:
+        - cluster
+      toPorts:
+        - ports:
+            - port: "{{ .Values.global.hubble.peerPort }}"
+              protocol: TCP

--- a/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/hubble-ui/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         k8s-app: {{ .Chart.Name }}
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/part-of: cilium
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       securityContext:
         fsGroup: 1001

--- a/charts/internal/cilium/charts/network-policy/templates/nodelocaldns.yaml
+++ b/charts/internal/cilium/charts/network-policy/templates/nodelocaldns.yaml
@@ -20,4 +20,27 @@ spec:
       - port: "53"
         name: dns-tcp
         protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: "nodelocaldns"
+spec:
+  endpointSelector:
+    matchLabels:
+      k8s:io.kubernetes.pod.namespace: kube-system
+      k8s-app: node-local-dns
+  ingress:
+    - fromEndpoints:
+        - {}
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: TCP
+            - port: "53"
+              protocol: UDP
+            - port: "9253"
+              protocol: TCP
+            - port: "9353"
+              protocol: TCP
 {{- end }}

--- a/charts/internal/cilium/charts/operator/templates/deployment.yaml
+++ b/charts/internal/cilium/charts/operator/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
         name: cilium-operator
         app.kubernetes.io/part-of: cilium
         app.kubernetes.io/name: cilium-operator
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       # In HA mode, cilium-operator pods must not be scheduled on the same
       # node as they will clash with each other.

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -51,10 +51,12 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 		Spec: gardencorev1beta1.ShootSpec{
 			Region:            "local",
 			SecretBindingName: ptr.To("local"),
-			CloudProfileName:  ptr.To("local"),
+			CloudProfile: &gardencorev1beta1.CloudProfileReference{
+				Name: "local",
+				Kind: "CloudProfile",
+			},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version:                     "1.30.0",
-				EnableStaticTokenKubeconfig: ptr.To(false),
+				Version: "1.30.0",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: ptr.To(false),
 					RegistryPullQPS:     ptr.To(int32(10)),
@@ -83,6 +85,11 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 					Minimum: 2,
 					Maximum: 2,
 				}},
+			},
+			SystemComponents: &gardencorev1beta1.SystemComponents{
+				NodeLocalDNS: &gardencorev1beta1.NodeLocalDNS{
+					Enabled: true,
+				},
 			},
 		},
 	}

--- a/test/e2e/network_connectivity_test.go
+++ b/test/e2e/network_connectivity_test.go
@@ -11,6 +11,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
@@ -33,6 +34,19 @@ var _ = Describe("Network Extension Tests", Label("Network"), func() {
 		defer cancel()
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 		f.Verify()
+
+		By("Create Deny-All Network Policy")
+		denyAllPolicy := &networkingv1.NetworkPolicy{
+			ObjectMeta: v1.ObjectMeta{Name: "deny-all", Namespace: templates.NetworkConnectivityTestNamespace},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: v1.LabelSelector{},
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+				Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+				Egress:      []networkingv1.NetworkPolicyEgressRule{},
+			},
+		}
+		err := f.ShootFramework.ShootClient.Client().Create(ctx, denyAllPolicy)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Test Networking")
 		ctx, cancel = context.WithTimeout(parentCtx, defaultTimeout)

--- a/test/templates/network-connectivity-test.yaml.tpl
+++ b/test/templates/network-connectivity-test.yaml.tpl
@@ -11,24 +11,11 @@ spec:
     metadata:
       labels:
         app: networking-test
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-apiserver: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       containers:
-      - image: europe-docker.pkg.dev/gardener-project/releases/gardener/cilium-cli:1.10.0
-        name: networking-shoot-tests-cilium-port-forward
-        command: [ "sh", "-c" ]
-        args:
-          - cilium-cli hubble port-forward
-        securityContext:
-          capabilities:
-            add:
-              - NET_ADMIN
-        env:
-          - name: KUBECONFIG
-            value: /etc/kubeconfig/kubeconfig
-        volumeMounts:
-          - name: shoot-kubeconfig
-            mountPath: "/etc/kubeconfig"
-            readOnly: true
       - image: europe-docker.pkg.dev/gardener-project/releases/gardener/cilium-cli:1.10.0
         name: networking-shoot-tests-cilium
         command: ["sh", "-c"]

--- a/test/templates/network-connectivity-test.yaml.tpl
+++ b/test/templates/network-connectivity-test.yaml.tpl
@@ -14,6 +14,22 @@ spec:
     spec:
       containers:
       - image: europe-docker.pkg.dev/gardener-project/releases/gardener/cilium-cli:1.10.0
+        name: networking-shoot-tests-cilium-port-forward
+        command: [ "sh", "-c" ]
+        args:
+          - cilium-cli hubble port-forward
+        securityContext:
+          capabilities:
+            add:
+              - NET_ADMIN
+        env:
+          - name: KUBECONFIG
+            value: /etc/kubeconfig/kubeconfig
+        volumeMounts:
+          - name: shoot-kubeconfig
+            mountPath: "/etc/kubeconfig"
+            readOnly: true
+      - image: europe-docker.pkg.dev/gardener-project/releases/gardener/cilium-cli:1.10.0
         name: networking-shoot-tests-cilium
         command: ["sh", "-c"]
         args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

- Added labels and network policies to make sure cilium still works with a deny-all policy present in the kube-system namespace.
- Added network policy to support node-local-dns
- Added network policy to support hubble

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Cilium extension now supports a deny-all network policy within the kube-system namespace that [will come with kubernetes v1.33](https://github.com/gardener/gardener/pull/11502)
```
