### PR TITLE
bump cilium-envoy to v1.32.5

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -21,7 +21,7 @@ images:
   - name: cilium-envoy
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium-envoy
-    tag: v1.31.6-1742787318-c0594713884ce0bbd31c80994b91435ca8d0209f
+    tag: v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf@sha256:a01cadf7974409b5c5c92ace3d6afa298408468ca24cab1cb413c04f89d3d1f9
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -33,10 +33,10 @@ images:
         availability_requirement: 'low'
     - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
       value:
-      # https://github.com/cilium/proxy: v1.17.1 -> v1.31.6
-      # https://www.envoyproxy.io/docs/envoy/v1.31.6/intro/arch_overview/security/external_deps
+      # https://github.com/cilium/proxy: v1.17.3 -> v1.32.5
+      # https://www.envoyproxy.io/docs/envoy/v1.32.5/intro/arch_overview/security/external_deps
       - name: 'c-ares'
-        version: '1.20.1'
+        version: '1.21.0'
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/operator

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -21,7 +21,7 @@ images:
   - name: cilium-envoy
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium-envoy
-    tag: v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf@sha256:a01cadf7974409b5c5c92ace3d6afa298408468ca24cab1cb413c04f89d3d1f9
+    tag: v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -21,7 +21,7 @@ images:
   - name: cilium-envoy
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium-envoy
-    tag: v1.31.5-1739264036-958bef243c6c66fcfd73ca319f2eb49fff1eb2ae
+    tag: v1.31.6-1742787318-c0594713884ce0bbd31c80994b91435ca8d0209f
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -33,8 +33,8 @@ images:
         availability_requirement: 'low'
     - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
       value:
-      # https://github.com/cilium/proxy: v1.17.1 -> v1.31.5
-      # https://www.envoyproxy.io/docs/envoy/v1.31.5/intro/arch_overview/security/external_deps
+      # https://github.com/cilium/proxy: v1.17.1 -> v1.31.6
+      # https://www.envoyproxy.io/docs/envoy/v1.31.6/intro/arch_overview/security/external_deps
       - name: 'c-ares'
         version: '1.20.1'
   - name: cilium-operator


### PR DESCRIPTION
bump glibc to v2.39 to fix issues found in v2.35

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:

A couple of issues were found that got fixed in glibc >= v2.39

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy dependency
cilium-envoy got updated to v1.32.5
```
