### PR TITLE
[GEP-28] Allow usage of extension in Autonomous Shoot Cluster scenario.

### DIFF
--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -203,7 +203,10 @@ func getConfigMap(ctx context.Context, cl client.Client, cluster *extensionscont
 	}
 	_, shootClient, err := util.NewClientForShoot(ctx, cl, cluster.ObjectMeta.Name, client.Options{}, extensionsconfig.RESTOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("could not create shoot client: %w", err)
+		// No need to report the error as this is anyway only best effort. Some scenarios, e.g. autonomous shoot clusters,
+		// might not have the gardener secret and hence cannot construct the shoot client here.
+		// RenderCiliumChart(...) has the real fallback logic in case the config map was not found/changed.
+		return &corev1.ConfigMap{}, nil
 	}
 	configmap := &corev1.ConfigMap{}
 	_ = shootClient.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: name}, configmap)

--- a/pkg/controller/actuator_reconcile.go
+++ b/pkg/controller/actuator_reconcile.go
@@ -176,7 +176,7 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, network *extens
 
 	configMapLabelPrefix, err := getConfigMap(ctx, a.client, cluster, "label-prefix-conf")
 	if err != nil {
-		return fmt.Errorf("error getting cilium configMap: %w", err)
+		return fmt.Errorf("error getting cilium label prefix configMap: %w", err)
 	}
 
 	ciliumChart, err := chartspkg.RenderCiliumChart(chartRenderer, networkConfig, network, cluster, getIPAMMode(configMap), getConfigMapHash(configMap), getConfigMapHash(configMapLabelPrefix))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

Allow usage of extension in Autonomous Shoot Cluster scenario.

Autonomous shoot clusters do not have the equivalent of the gardener secret containing a kubeconfig for the control plane. As seed and shoot cluster are basically the same thing in this scenario there is no need for this secret. Therefore, extensions should work with what they have.
While it is possible to just use the seed client instead, in this case it is also possible to simply not retrieve the config maps at all because there is anyway a fallback logic in place. This way the code is not cluttered with autonomous shoot cluster specifics, but will continue to work nevertheless.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2906

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow networking-cilium extension to be used in autonomous shoot clusters.
```
