### PR TITLE
feat: allow disabling BPF masquerading

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -332,7 +332,7 @@ data:
 
   enable-ipv4-big-tcp: {{ .Values.global.enableIpv4BigTCP | quote }}
 {{- if .Values.global.ipv4.enabled }}
-  enable-ipv4-masquerade: "true"
+  enable-ipv4-masquerade: {{ .Values.global.enableIpv6Masquerade | quote }}
 {{- else }}
   enable-ipv4-masquerade: "false"
 {{- end }}

--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -332,7 +332,7 @@ data:
 
   enable-ipv4-big-tcp: {{ .Values.global.enableIpv4BigTCP | quote }}
 {{- if .Values.global.ipv4.enabled }}
-  enable-ipv4-masquerade: {{ .Values.global.enableIpv6Masquerade | quote }}
+  enable-ipv4-masquerade: {{ .Values.global.enableIpv4Masquerade | quote }}
 {{- else }}
   enable-ipv4-masquerade: "false"
 {{- end }}

--- a/hack/api-reference/cilium.md
+++ b/hack/api-reference/cilium.md
@@ -299,6 +299,42 @@ SnatOutOfCluster
 </tr>
 <tr>
 <td>
+<code>enableIpv4Masquerade</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableIPv4Masquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enableIpv6Masquerade</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableIPv6Masquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enableBPFMasquerade</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableBPFMasquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>bgpControlPlane</code></br>
 <em>
 <a href="#cilium.networking.extensions.gardener.cloud/v1alpha1.BGPControlPlane">

--- a/pkg/apis/cilium/types_network.go
+++ b/pkg/apis/cilium/types_network.go
@@ -206,6 +206,12 @@ type NetworkConfig struct {
 	SnatToUpstreamDNS *SnatToUpstreamDNS
 	// SnatOutOfCluster enables the masquerading of packets outside of the cluster
 	SnatOutOfCluster *SnatOutOfCluster
+	// EnableIPv4Masquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled
+	EnableIPv4Masquerade *bool
+	// EnableIPv6Masquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled
+	EnableIPv6Masquerade *bool
+	// EnableBPFMasquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled
+	EnableBPFMasquerade *bool
 	// BGPControlPlane enables the BGP Control Plane
 	BGPControlPlane *BGPControlPlane
 }

--- a/pkg/apis/cilium/v1alpha1/types_network.go
+++ b/pkg/apis/cilium/v1alpha1/types_network.go
@@ -219,6 +219,15 @@ type NetworkConfig struct {
 	// SnatOutOfCluster enables the masquerading of packets outside of the cluster
 	// +optional
 	SnatOutOfCluster *SnatOutOfCluster `json:"snatOutOfCluster,omitempty"`
+	// EnableIPv4Masquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled
+	// +optional
+	EnableIPv4Masquerade *bool `json:"enableIpv4Masquerade,omitempty"`
+	// EnableIPv6Masquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled
+	// +optional
+	EnableIPv6Masquerade *bool `json:"enableIpv6Masquerade,omitempty"`
+	// EnableBPFMasquerade masquerades packets from endpoints leaving the host with BPF instead of iptables if Snat is not enabled
+	// +optional
+	EnableBPFMasquerade *bool `json:"enableBPFMasquerade,omitempty"`
 	// BGPControlPlane enables the BGP Control Plane
 	// +optional
 	BGPControlPlane *BGPControlPlane `json:"bgpControlPlane,omitempty"`

--- a/pkg/apis/cilium/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/cilium/v1alpha1/zz_generated.conversion.go
@@ -349,6 +349,9 @@ func autoConvert_v1alpha1_NetworkConfig_To_cilium_NetworkConfig(in *NetworkConfi
 	out.Overlay = (*cilium.Overlay)(unsafe.Pointer(in.Overlay))
 	out.SnatToUpstreamDNS = (*cilium.SnatToUpstreamDNS)(unsafe.Pointer(in.SnatToUpstreamDNS))
 	out.SnatOutOfCluster = (*cilium.SnatOutOfCluster)(unsafe.Pointer(in.SnatOutOfCluster))
+	out.EnableIPv4Masquerade = (*bool)(unsafe.Pointer(in.EnableIPv4Masquerade))
+	out.EnableIPv6Masquerade = (*bool)(unsafe.Pointer(in.EnableIPv6Masquerade))
+	out.EnableBPFMasquerade = (*bool)(unsafe.Pointer(in.EnableBPFMasquerade))
 	out.BGPControlPlane = (*cilium.BGPControlPlane)(unsafe.Pointer(in.BGPControlPlane))
 	return nil
 }
@@ -378,6 +381,9 @@ func autoConvert_cilium_NetworkConfig_To_v1alpha1_NetworkConfig(in *cilium.Netwo
 	out.Overlay = (*Overlay)(unsafe.Pointer(in.Overlay))
 	out.SnatToUpstreamDNS = (*SnatToUpstreamDNS)(unsafe.Pointer(in.SnatToUpstreamDNS))
 	out.SnatOutOfCluster = (*SnatOutOfCluster)(unsafe.Pointer(in.SnatOutOfCluster))
+	out.EnableIPv4Masquerade = (*bool)(unsafe.Pointer(in.EnableIPv4Masquerade))
+	out.EnableIPv6Masquerade = (*bool)(unsafe.Pointer(in.EnableIPv6Masquerade))
+	out.EnableBPFMasquerade = (*bool)(unsafe.Pointer(in.EnableBPFMasquerade))
 	out.BGPControlPlane = (*BGPControlPlane)(unsafe.Pointer(in.BGPControlPlane))
 	return nil
 }

--- a/pkg/apis/cilium/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cilium/v1alpha1/zz_generated.deepcopy.go
@@ -250,6 +250,21 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(SnatOutOfCluster)
 		**out = **in
 	}
+	if in.EnableIPv4Masquerade != nil {
+		in, out := &in.EnableIPv4Masquerade, &out.EnableIPv4Masquerade
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableIPv6Masquerade != nil {
+		in, out := &in.EnableIPv6Masquerade, &out.EnableIPv6Masquerade
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableBPFMasquerade != nil {
+		in, out := &in.EnableBPFMasquerade, &out.EnableBPFMasquerade
+		*out = new(bool)
+		**out = **in
+	}
 	if in.BGPControlPlane != nil {
 		in, out := &in.BGPControlPlane, &out.BGPControlPlane
 		*out = new(BGPControlPlane)

--- a/pkg/apis/cilium/zz_generated.deepcopy.go
+++ b/pkg/apis/cilium/zz_generated.deepcopy.go
@@ -282,6 +282,21 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(SnatOutOfCluster)
 		**out = **in
 	}
+	if in.EnableIPv4Masquerade != nil {
+		in, out := &in.EnableIPv4Masquerade, &out.EnableIPv4Masquerade
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableIPv6Masquerade != nil {
+		in, out := &in.EnableIPv6Masquerade, &out.EnableIPv6Masquerade
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableBPFMasquerade != nil {
+		in, out := &in.EnableBPFMasquerade, &out.EnableBPFMasquerade
+		*out = new(bool)
+		**out = **in
+	}
 	if in.BGPControlPlane != nil {
 		in, out := &in.BGPControlPlane, &out.BGPControlPlane
 		*out = new(BGPControlPlane)

--- a/pkg/charts/config.go
+++ b/pkg/charts/config.go
@@ -45,6 +45,9 @@ type globalConfig struct {
 	IPAM                     ipam                                    `json:"ipam"`
 	SnatToUpstreamDNS        snatToUpstreamDNS                       `json:"snatToUpstreamDNS"`
 	SnatOutOfCluster         snatOutOfCluster                        `json:"snatOutOfCluster"`
+	EnableIPv4Masquerade     bool                                    `json:"enableIpv4Masquerade"`
+	EnableIPv6Masquerade     bool                                    `json:"enableIpv6Masquerade"`
+	EnableBPFMasquerade      bool                                    `json:"enableBPFMasquerade"`
 	AutoDirectNodeRoutes     bool                                    `json:"autoDirectNodeRoutes"`
 	BGPControlPlane          bgpControlPlane                         `json:"bgpControlPlane"`
 	ConfigMapHash            string                                  `json:"configMapHash"`

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -107,6 +107,9 @@ var defaultGlobalConfig = globalConfig{
 	SnatOutOfCluster: snatOutOfCluster{
 		Enabled: false,
 	},
+	EnableIPv4Masquerade: true,
+	EnableIPv6Masquerade: false,
+	EnableBPFMasquerade:  true,
 	AutoDirectNodeRoutes: false,
 	BGPControlPlane: bgpControlPlane{
 		Enabled: false,
@@ -289,6 +292,18 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 
 	if config.SnatOutOfCluster != nil && config.SnatOutOfCluster.Enabled {
 		globalConfig.SnatOutOfCluster.Enabled = config.SnatOutOfCluster.Enabled
+	}
+
+	if config.EnableIPv4Masquerade != nil {
+		globalConfig.EnableIPv4Masquerade = *config.EnableIPv4Masquerade
+	}
+
+	if config.EnableIPv6Masquerade != nil {
+		globalConfig.EnableIPv6Masquerade = *config.EnableIPv6Masquerade
+	}
+
+	if config.EnableBPFMasquerade != nil {
+		globalConfig.EnableBPFMasquerade = *config.EnableBPFMasquerade
 	}
 
 	if config.Overlay != nil && !config.Overlay.Enabled && config.Overlay.CreatePodRoutes != nil {

--- a/renovate.json5
+++ b/renovate.json5
@@ -93,7 +93,6 @@
     "github.com/google/btree",
     "github.com/google/gnostic-models",
     "github.com/google/go-cmp",
-    "github.com/google/gofuzz",
     "github.com/google/pprof",
     "github.com/google/uuid",
     "github.com/gorilla/websocket",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind api-change

**What this PR does / why we need it**:
In one of our setups with metal-stack and Cilium the BPF masquerading needs to be disabled in order to work.

**Special notes for your reviewer**:
I simply added the fields to override the existing values in the values.yaml of the internal helm chart. Most other fields could already be set. Therefore I just expanded the current approach.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allows disabling IPv4, IPv6 and BPF masquerading in networking-cilium extension.
```
