### PR TITLE
switch from maximum to minimum worker count for operator ha decision

### DIFF
--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -157,7 +157,7 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 		countOfApplicableWorkerNodes := 0
 
 		// Iterate over all worker groups and accumulate the guaranteed (minimum) count.
-		// HA requires two or more guaranteed nodes; anything less won’t reliably support a secondary operator instance.
+		// HA requires two or more guaranteed nodes. Anything less won’t reliably support a secondary operator instance.
 		for _, k := range cluster.Shoot.Spec.Provider.Workers {
 			countOfApplicableWorkerNodes += int(k.Minimum)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/area cost
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
This change updates the Cilium operator’s HA check to sum each `workerGroup.Minimum` instead of `workerGroup.Maximum`. By relying on the guaranteed minimum node count, HA is enabled only when two nodes are truly available. Otherwise, HA mode would spin up a second node in single-node clusters, wasting CPU, memory, and extra billing. HA remains ensured for any shoot whose minimum node count is ≥ 2 (as all HA shoots should require). This tweak aligns with the “Leaner Clusters, Lower Bills” approach ([https://gardener.cloud/blog/2025/04-17-leaner-clusters-lower-bills/](https://gardener.cloud/blog/2025/04-17-leaner-clusters-lower-bills/)) by avoiding unnecessary resource usage when HA is not actually needed.

In our Slack discussion, we agreed that single-node clusters were not the original focus for HA behavior, but cost-conscious users would benefit from only enabling HA when a cluster truly has two guaranteed nodes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```noteworthy operator
Cilium operator HA logic now uses guaranteed (minimum) node count instead of maximum, preventing unnecessary node spin-up and reducing compute costs in single-node clusters; HA remains guaranteed for shoots with minimum ≥ 2.
```
