### PR TITLE
fix: disable vpa to stabilize con tests

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -12,6 +12,8 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/test/framework"
 	. "github.com/onsi/ginkgo/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -46,6 +48,8 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			Annotations: map[string]string{
 				v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds: "0",
 				v1beta1constants.ShootDisableIstioTLSTermination:                    "true",
+				v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled:            "true",
+				v1beta1constants.ShootAlphaControlPlaneVPNVPAUpdateDisabled:         "true",
 			},
 		},
 		Spec: gardencorev1beta1.ShootSpec{
@@ -65,6 +69,17 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 				KubeProxy: &gardencorev1beta1.KubeProxyConfig{
 					Mode:    ptr.To(gardencorev1beta1.ProxyModeIPTables),
 					Enabled: ptr.To(false),
+				},
+				VerticalPodAutoscaler: &gardencorev1beta1.VerticalPodAutoscaler{
+					Enabled: false,
+				},
+				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+					Autoscaling: &gardencorev1beta1.ControlPlaneAutoscaling{
+						MinAllowed: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceCPU:    resource.MustParse("250m"),
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+						},
+					},
 				},
 			},
 			Networking: &gardencorev1beta1.Networking{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind flake

**What this PR does / why we need it**:

- I've observed many intermittent failures of the connectivity test that are caused by VPA evictions of kube-apiserver, vpn-shoot or vpn-seed-server mid-test
- This PR disables VPA and other autoscaling of kube-apiserver and vpn components in an effort to get more stability into the connectivity test.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
connectivity test stability has been improved and should be less flaky now
```
