### PR TITLE
allow hubble-generate-certs job access to api (via internal domain)

### DIFF
--- a/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
@@ -17,8 +17,8 @@ spec:
         metadata:
           labels:
             k8s-app: hubble-generate-certs
-          networking.gardener.cloud/to-public-networks: allowed
-          networking.gardener.cloud/to-dns: allowed
+            networking.gardener.cloud/to-public-networks: allowed
+            networking.gardener.cloud/to-dns: allowed
         spec:
           securityContext:
             seccompProfile:

--- a/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
@@ -17,6 +17,8 @@ spec:
         metadata:
           labels:
             k8s-app: hubble-generate-certs
+          networking.gardener.cloud/to-public-networks: allowed
+          networking.gardener.cloud/to-dns: allowed
         spec:
           securityContext:
             seccompProfile:

--- a/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
@@ -16,6 +16,8 @@ spec:
     metadata:
       labels:
         k8s-app: hubble-generate-certs
+        networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-dns: allowed
     spec:
       containers:
         - name: certgen


### PR DESCRIPTION
**How to categorize this PR?**
/area networking
/kind bug

**What this PR does / why we need it**:
Add labels for access to dns and api

**Which issue(s) this PR fixes**:
Fixes #604

**Special notes for your reviewer**:
Should this be implemented in network-policy?

**Release note**:
```
category: bugfix
fix hubble-generate-certs using labels 
```