### PR TITLE
Fix Prometheus relabeling and service discovery misconfigurations

### DIFF
--- a/charts/internal/cilium-monitoring/templates/scrapeconfig-agent.yaml
+++ b/charts/internal/cilium-monitoring/templates/scrapeconfig-agent.yaml
@@ -55,7 +55,7 @@ spec:
     replacement: kube-apiserver:443
   - sourceLabels: [__meta_kubernetes_pod_name]
     separator: ;
-    regex: (.+);(.+)
+    regex: (.+)
     targetLabel: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9090/proxy/metrics
     action: replace

--- a/charts/internal/cilium-monitoring/templates/scrapeconfig-hubble.yaml
+++ b/charts/internal/cilium-monitoring/templates/scrapeconfig-hubble.yaml
@@ -55,7 +55,7 @@ spec:
     replacement: kube-apiserver:443
   - sourceLabels: [__meta_kubernetes_pod_name]
     separator: ;
-    regex: (.+);(.+)
+    regex: (.+)
     targetLabel: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
     action: replace

--- a/charts/internal/cilium-monitoring/templates/scrapeconfig-operator.yaml
+++ b/charts/internal/cilium-monitoring/templates/scrapeconfig-operator.yaml
@@ -25,7 +25,7 @@ spec:
     namespaces:
       names:
       - kube-system
-    role: Endpoints
+    role: pod
     tlsConfig:
       # This is needed because we do not fetch the correct cluster CA bundle right now
       insecureSkipVerify: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
This commit fixes multiple misconfigurations in three Prometheus ScrapeConfigs:

`cilium-operator`: 6c7ddad incorrectly configured the kubernetes service discovery to look for (non-existent) `cilium-operator` endpoints. Previously, this ScrapeConfigs used the `pod` role.

`cilium-agent` and `hubble-metrics`: The same commit introduced a bad regex to the relabel_config that included two capturing groups. This caused no metrics to be retained for these two jobs.

**Special notes for your reviewer**:
FYI @ScheererJ @axel7born 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixes some more bugs in Prometheus ScrapeConfigs that prevented Cilium metrics from being collected.
```
