### PR TITLE
Fix migration to dual-stack

### DIFF
--- a/pkg/controller/status.go
+++ b/pkg/controller/status.go
@@ -35,10 +35,10 @@ func (a *actuator) updateProviderStatus(
 		100,
 		"Cilium was configured successfully")
 	var ipFamilies []extensionsv1alpha1.IPFamily
-	if config.IPv4 != nil {
+	if config.IPv4 != nil && config.IPv4.Enabled {
 		ipFamilies = append(ipFamilies, extensionsv1alpha1.IPFamilyIPv4)
 	}
-	if config.IPv6 != nil {
+	if config.IPv6 != nil && config.IPv6.Enabled {
 		ipFamilies = append(ipFamilies, extensionsv1alpha1.IPFamilyIPv6)
 	}
 	network.Status.IPFamilies = ipFamilies


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Check if IPFamily is enabled before adding to status. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixes an issue where network status is not correct during migration to dual-stack. 
```
