### PR TITLE
feat: make the Cilium policy-audit-mode configurable

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -578,8 +578,8 @@ data:
 {{- if hasKey .Values "synchronizeK8sNodes" }}
   synchronize-k8s-nodes: {{ .Values.synchronizeK8sNodes | quote }}
 {{- end }}
-{{- if .Values.policyAuditMode }}
-  policy-audit-mode: {{ .Values.policyAuditMode | quote }}
+{{- if .Values.global.policyAuditMode }}
+  policy-audit-mode: {{ .Values.global.policyAuditMode | quote }}
 {{- end }}
 
 {{- if ne $defaultOperatorApiServeAddr "localhost:9234" }}

--- a/hack/api-reference/cilium.md
+++ b/hack/api-reference/cilium.md
@@ -347,6 +347,18 @@ BGPControlPlane
 <p>BGPControlPlane enables the BGP Control Plane</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>policyAuditMode</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>PolicyAuditMode enables non-drop mode for installed policies</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="cilium.networking.extensions.gardener.cloud/v1alpha1.BGPControlPlane">BGPControlPlane

--- a/pkg/apis/cilium/types_network.go
+++ b/pkg/apis/cilium/types_network.go
@@ -205,6 +205,8 @@ type NetworkConfig struct {
 	EnableBPFMasquerade *bool
 	// BGPControlPlane enables the BGP Control Plane
 	BGPControlPlane *BGPControlPlane
+	// PolicyAuditMode enables non-drop mode for installed policies
+	PolicyAuditMode *bool
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/cilium/v1alpha1/types_network.go
+++ b/pkg/apis/cilium/v1alpha1/types_network.go
@@ -231,6 +231,9 @@ type NetworkConfig struct {
 	// BGPControlPlane enables the BGP Control Plane
 	// +optional
 	BGPControlPlane *BGPControlPlane `json:"bgpControlPlane,omitempty"`
+	// PolicyAuditMode enables non-drop mode for installed policies
+	// +optional
+	PolicyAuditMode *bool `json:"policyAuditMode,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/cilium/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/cilium/v1alpha1/zz_generated.conversion.go
@@ -353,6 +353,7 @@ func autoConvert_v1alpha1_NetworkConfig_To_cilium_NetworkConfig(in *NetworkConfi
 	out.EnableIPv6Masquerade = (*bool)(unsafe.Pointer(in.EnableIPv6Masquerade))
 	out.EnableBPFMasquerade = (*bool)(unsafe.Pointer(in.EnableBPFMasquerade))
 	out.BGPControlPlane = (*cilium.BGPControlPlane)(unsafe.Pointer(in.BGPControlPlane))
+	out.PolicyAuditMode = (*bool)(unsafe.Pointer(in.PolicyAuditMode))
 	return nil
 }
 
@@ -385,6 +386,7 @@ func autoConvert_cilium_NetworkConfig_To_v1alpha1_NetworkConfig(in *cilium.Netwo
 	out.EnableIPv6Masquerade = (*bool)(unsafe.Pointer(in.EnableIPv6Masquerade))
 	out.EnableBPFMasquerade = (*bool)(unsafe.Pointer(in.EnableBPFMasquerade))
 	out.BGPControlPlane = (*BGPControlPlane)(unsafe.Pointer(in.BGPControlPlane))
+	out.PolicyAuditMode = (*bool)(unsafe.Pointer(in.PolicyAuditMode))
 	return nil
 }
 

--- a/pkg/apis/cilium/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/cilium/v1alpha1/zz_generated.deepcopy.go
@@ -270,6 +270,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(BGPControlPlane)
 		**out = **in
 	}
+	if in.PolicyAuditMode != nil {
+		in, out := &in.PolicyAuditMode, &out.PolicyAuditMode
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/cilium/zz_generated.deepcopy.go
+++ b/pkg/apis/cilium/zz_generated.deepcopy.go
@@ -270,6 +270,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(BGPControlPlane)
 		**out = **in
 	}
+	if in.PolicyAuditMode != nil {
+		in, out := &in.PolicyAuditMode, &out.PolicyAuditMode
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/charts/config.go
+++ b/pkg/charts/config.go
@@ -53,6 +53,7 @@ type globalConfig struct {
 	BGPControlPlane                     bgpControlPlane                         `json:"bgpControlPlane"`
 	ConfigMapHash                       string                                  `json:"configMapHash"`
 	ConfigMapLabelPrefixHash            string                                  `json:"configMapLabelPrefixHash"`
+	PolicyAuditMode                     bool                                    `json:"policyAuditMode"`
 }
 
 // etcd related configuration for cilium

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -117,6 +117,7 @@ var defaultGlobalConfig = globalConfig{
 	},
 	ConfigMapHash:            "",
 	ConfigMapLabelPrefixHash: "",
+	PolicyAuditMode:          false,
 }
 
 func newGlobalConfig() globalConfig {
@@ -310,6 +311,10 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 
 	if config.EnableBPFMasquerade != nil {
 		globalConfig.EnableBPFMasquerade = *config.EnableBPFMasquerade
+	}
+
+	if config.PolicyAuditMode != nil {
+		globalConfig.PolicyAuditMode = *config.PolicyAuditMode
 	}
 
 	if config.Overlay != nil && !config.Overlay.Enabled && config.Overlay.CreatePodRoutes != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area ops-productivity
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

This PR allows you to enable the `policy-audit-mode` in Cilium. This is very useful when you want to test network policies before enforcing them. For example in case of an existing cluster for which you want to enforce network policies. Using the `policy-audit-mode` you can introduce network policies in a non-intrusive way.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I modified the key for the `policyAuditMode` value to `global.policyAuditMode` as most of the other values in the config chart also take global values. Also, the config chart does not have a values file itself, so I think that taking it from the global values is appropriate.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allows enabling policy audit mode in networking-cilium extension.
```
