### PR TITLE
Hotfix: Update cilium images to v1.17.7 (patch)

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -84,6 +84,8 @@ spec:
             httpHeaders:
             - name: "brief"
               value: "true"
+            - name: "require-k8s-connectivity"
+              value: "false"
 {{- end }}
           failureThreshold: 10
           periodSeconds: 30

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -2,7 +2,7 @@ images:
   - name: cilium-agent
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium
-    tag: v1.17.6
+    tag: v1.17.7
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -14,14 +14,14 @@ images:
         availability_requirement: 'high'
     - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
       value:
-      # https://github.com/cilium/proxy: v1.17.1 -> v1.31.5
-      # https://www.envoyproxy.io/docs/envoy/v1.31.5/intro/arch_overview/security/external_deps
+      # https://github.com/cilium/proxy: v1.17.7 -> v1.33.6
+      # https://www.envoyproxy.io/docs/envoy/v1.33.6/intro/arch_overview/security/external_deps
       - name: 'v8'
-        version: '10.7.193.13'
+        version: '12.9.202.27'
   - name: cilium-envoy
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium-envoy
-    tag: v1.32.5-1744305768-f9ddca7dcd91f7ca25a505560e655c47d3dec2cf
+    tag: v1.33.6-1754542786-4d9638583910acb3e34d77e436cbd745d910a437
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -33,14 +33,14 @@ images:
         availability_requirement: 'low'
     - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
       value:
-      # https://github.com/cilium/proxy: v1.17.3 -> v1.32.5
-      # https://www.envoyproxy.io/docs/envoy/v1.32.5/intro/arch_overview/security/external_deps
+      # https://github.com/cilium/proxy: v1.17.7 -> v1.33.6
+      # https://www.envoyproxy.io/docs/envoy/v1.33.6/intro/arch_overview/security/external_deps
       - name: 'c-ares'
         version: '1.21.0'
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/operator
-    tag: v1.17.6
+    tag: v1.17.7
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -79,7 +79,7 @@ images:
   - name: hubble-relay
     sourceRepository: github.com/cilium/hubble-ui
     repository: quay.io/cilium/hubble-relay
-    tag: v1.17.6
+    tag: v1.17.7
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

chore(deps): update cilium images to v1.17.7 (patch) (#621)

* chore(deps): update cilium images to v1.17.7

* Update cilium-envoy image

* Update liveness probe to not check for kubernetes connectivity

* Run `make generate`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update cilium to v1.17.7
```
