### PR TITLE
Make `add-snat-rule-to-upstream-dns` and `add-snat-rule-to-outside-world` container scripts react to `SIGTERM`

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -275,7 +275,16 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "while true; do sleep 15; for i in $(cat /etc/resolv.conf | grep nameserver | awk '{print $2}' ); do iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d $i/32 ! -o cilium_+ -m comment --comment \"cilium masquerade non-cluster\" -j MASQUERADE 2>/dev/null || iptables -t nat -I CILIUM_POST_nat 1 -s ${POD_CIDR} -d $i/32 ! -o cilium_+ -m comment --comment \"cilium masquerade non-cluster\" -j MASQUERADE; done; sleep 45; done"
+        - |
+          trap 'echo Received SIGTERM, exiting...' TERM
+          (while true; do
+            sleep 15
+            for i in $(cat /etc/resolv.conf | grep nameserver | awk '{print $2}' ); do
+              iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d $i/32 ! -o cilium_+ -m comment --comment "cilium masquerade non-cluster" -j MASQUERADE 2>/dev/null || iptables -t nat -I CILIUM_POST_nat 1 -s ${POD_CIDR} -d $i/32 ! -o cilium_+ -m comment --comment "cilium masquerade non-cluster" -j MASQUERADE
+            done
+            sleep 45
+          done)&
+          wait
 {{- end }}
       # Masquerade traffic outside of pod cidr range and node cidr range
 {{- if .Values.global.snatOutOfCluster.enabled }}
@@ -299,7 +308,16 @@ spec:
         command:
         - /bin/sh
         - -c
-        - "while true; do sleep 15; iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d ${POD_CIDR} -j RETURN 2>/dev/null || iptables -t nat -A CILIUM_POST_nat -s ${POD_CIDR} -d ${POD_CIDR} -j RETURN; iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d ${NODE_CIDR} -j RETURN 2>/dev/null  || iptables -t nat -A CILIUM_POST_nat -s ${POD_CIDR} -d ${NODE_CIDR} -j RETURN; iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d 0.0.0.0/0 ! -o cilium_+ -m comment --comment \"cilium masquerade non-cluster\" -j MASQUERADE || iptables -t nat -A CILIUM_POST_nat -s ${POD_CIDR} -d 0.0.0.0/0 ! -o cilium_+ -m comment --comment \"cilium masquerade non-cluster\" -j MASQUERADE; sleep 45; done"
+        - |
+          trap 'echo Received SIGTERM, exiting...' TERM
+          (while true; do
+            sleep 15
+            iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d ${POD_CIDR} -j RETURN 2>/dev/null || iptables -t nat -A CILIUM_POST_nat -s ${POD_CIDR} -d ${POD_CIDR} -j RETURN
+            iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d ${NODE_CIDR} -j RETURN 2>/dev/null  || iptables -t nat -A CILIUM_POST_nat -s ${POD_CIDR} -d ${NODE_CIDR} -j RETURN
+            iptables -t nat -C CILIUM_POST_nat -s ${POD_CIDR} -d 0.0.0.0/0 ! -o cilium_+ -m comment --comment "cilium masquerade non-cluster" -j MASQUERADE || iptables -t nat -A CILIUM_POST_nat -s ${POD_CIDR} -d 0.0.0.0/0 ! -o cilium_+ -m comment --comment "cilium masquerade non-cluster" -j MASQUERADE
+            sleep 45
+          done)&
+          wait
 {{- end }}
       initContainers:
       # Disable source validation / rp_filter.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind robustness

**What this PR does / why we need it**:

Make `add-snat-rule-to-upstream-dns` and `add-snat-rule-to-outside-world` container scripts react to `SIGTERM`.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

This change is analogous to https://github.com/gardener/gardener-extension-networking-calico/pull/710.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A background script in the cilium agent pod now properly reacts to SIGTERM allowing for faster node reboots. 
```
