### PR TITLE
Create a new CA in Job and CronJob.

### DIFF
--- a/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/cronjob.yaml
@@ -40,7 +40,6 @@ spec:
               # the values used in past runs by inspecting the completed pod.
               args:
                 - "--ca-generate=true"
-                - "--ca-reuse-secret"
                 - "--ca-secret-namespace=kube-system"
                 - "--ca-secret-name=cilium-ca"
                 - "--ca-common-name=Cilium CA"

--- a/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
@@ -36,7 +36,6 @@ spec:
           # the values used in past runs by inspecting the completed pod.
           args:
             - "--ca-generate=true"
-            - "--ca-reuse-secret"
             - "--ca-secret-namespace=kube-system"
             - "--ca-secret-name=cilium-ca"
             - "--ca-common-name=Cilium CA"
@@ -73,4 +72,3 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       restartPolicy: OnFailure
-  ttlSecondsAfterFinished: 86400


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
The CA `cilium-ca` that is used to create ` hubble-relay-client-certs` and `hubble-server-certs` was never updated. It has a validity of 3 years and will expire without manual intervention.
Without the flag `--ca-reuse-secret` the CA is update with each run of the `Job` and the `CronJob`.
Certificates and CA are valid for 3 years. Running the Cronjob every 4 months should be enough.
Looking at `hubble-ui`, I didn't see any disruption during the certificate renewal.

Deleted the TTL in the job, so it's not GC'ed and not re-run each day.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
An issue is fixed, that the cilium CA is never renewed.
```
