### PR TITLE
update node-local-dns mutate function to init sidecar approach

### DIFF
--- a/pkg/webhook/shoot/node_local_dns.go
+++ b/pkg/webhook/shoot/node_local_dns.go
@@ -42,10 +42,12 @@ func (m *mutator) mutateNodeLocalDNSDaemonSet(ctx context.Context, daemonset *ap
 			daemonset.Spec.Template.Spec.Containers[k].Args = append(daemonset.Spec.Template.Spec.Containers[k].Args, ciliumArgs...)
 			daemonset.Spec.Template.Spec.Containers[k].LivenessProbe.HTTPGet.Host = ""
 		}
+	}
+	for k, v := range daemonset.Spec.Template.Spec.InitContainers {
 		if v.Name == "coredns-config-adapter" {
-			for i, arg := range daemonset.Spec.Template.Spec.Containers[k].Args {
+			for i, arg := range daemonset.Spec.Template.Spec.InitContainers[k].Args {
 				if strings.Contains(arg, "bind=") {
-					daemonset.Spec.Template.Spec.Containers[k].Args[i] = "-bind=bind 0.0.0.0"
+					daemonset.Spec.Template.Spec.InitContainers[k].Args[i] = "-bind=bind 0.0.0.0"
 				}
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Update `node-local-dns` mutate function to init sidecar approach.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update `node-local-dns` mutate function to init sidecar approach.
```
