### PR TITLE
feat: enable automerge with renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "github>gardener/ci-infra//config/renovate/automerge-with-tide.json5"
   ],
   "labels": ["kind/enhancement"],
   "postUpdateOptions": ["gomodTidy"],
@@ -25,12 +26,14 @@
       "groupName": "cilium images",
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["quay\\.io\/cilium\/.+"],
+      "automerge": false
     },
     {
       // Group golang updates in one PR.
       "groupName": "golang",
       "matchDatasources": ["docker", "go-version"],
       "matchPackagePatterns": ["golang"],
+      "automerge": true
     },
     {
       // Group gardener updates in one PR.
@@ -39,6 +42,7 @@
       matchPackageNames: [
         '/^github\\.com/gardener/',
       ],
+      "automerge": true
     },
     {
       // Ignore paths which most likely create false positives.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
- Enable auto-merge with tide for non-cilium dependency updates
- Cilium updates will still have to be merged manually due to possible chart updates needed

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
