### PR TITLE
Skip encryption test in clilium connection tests.

### DIFF
--- a/test/templates/network-connectivity-test.yaml.tpl
+++ b/test/templates/network-connectivity-test.yaml.tpl
@@ -20,7 +20,7 @@ spec:
         name: networking-shoot-tests-cilium
         command: ["sh", "-c"]
         args:
-        - cilium-cli connectivity test --test '!to-entities-world,!to-fqdns,!client-egress-l7,!client-egress-l7-named-port,!client-egress-tls-sni,!check-log-errors'
+        - cilium-cli connectivity test --test '!to-entities-world,!to-fqdns,!client-egress-l7,!client-egress-l7-named-port,!client-egress-tls-sni,!check-log-errors,!pod-to-pod-encryption,!pod-to-pod-with-l7-policy-encryption,!node-to-node-encryption'
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind test

**What this PR does / why we need it**:
Probably due to a kind update in gardener/gardener that enforced stricter runtime security the encryption tests don't run any longer. Skip them until we have a fix in g/g.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
