### PR TITLE
passthrough hubble networkConfig to helm global values

### DIFF
--- a/pkg/charts/config.go
+++ b/pkg/charts/config.go
@@ -56,6 +56,7 @@ type globalConfig struct {
 	ConfigMapLabelPrefixHash            string                                  `json:"configMapLabelPrefixHash"`
 	PolicyAuditMode                     bool                                    `json:"policyAuditMode"`
 	Encryption                          encryption                              `json:"encryption"`
+	Hubble                              hubbleConfig                            `json:"hubble"`
 }
 
 // etcd related configuration for cilium
@@ -208,4 +209,8 @@ type encryptionWireguard struct {
 type encryptionWireguardStrictMode struct {
 	Enabled                   bool `json:"enabled"`
 	AllowRemoteNodeIdentities bool `json:"allowRemoteNodeIdentities"`
+}
+
+type hubbleConfig struct {
+	Enabled bool `json:"enabled"`
 }

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -125,6 +125,9 @@ var defaultGlobalConfig = globalConfig{
 		NodeEncryption: false,
 		Enabled:        false,
 	},
+	Hubble: hubbleConfig{
+		Enabled: false,
+	},
 }
 
 func newGlobalConfig() globalConfig {
@@ -214,9 +217,9 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 		return requirementsConfig, globalConfig, nil
 	}
 
-	// If Hubble enabled
-	if config.Hubble != nil && config.Hubble.Enabled {
+	if config.Hubble != nil {
 		requirementsConfig.Hubble.Enabled = config.Hubble.Enabled
+		globalConfig.Hubble.Enabled = config.Hubble.Enabled
 	}
 
 	// If ETCD enabled

--- a/pkg/charts/utils_test.go
+++ b/pkg/charts/utils_test.go
@@ -1,6 +1,9 @@
 package charts
 
 import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -41,6 +44,29 @@ var _ = Describe("#applyEncryptionConfig", func() {
 				}
 				Expect(applyEncryptionConfig(cfg, config)).ShouldNot(HaveOccurred())
 				Expect(cfg.Encryption.Wireguard.StrictMode.AllowRemoteNodeIdentities).To(BeTrue())
+			})
+		})
+	})
+})
+
+var _ = Describe("#generateChartValues", func() {
+	Describe("hubble", func() {
+		var config *ciliumv1alpha1.NetworkConfig
+		cluster := &extensions.Cluster{
+			Shoot: &gardencorev1beta1.Shoot{},
+		}
+		BeforeEach(func() {
+			config = &ciliumv1alpha1.NetworkConfig{}
+		})
+		Describe("reflect hubble of NetworkConfig in both requirementsConfig and globalConfig", func() {
+			It("should be disabled in requirementsConfig and globalConfig", func() {
+				config.Hubble = &ciliumv1alpha1.Hubble{
+					Enabled: false,
+				}
+				requirementCfg, globalCfg, err := generateChartValues(config, &extensionsv1alpha1.Network{}, cluster, "", "", "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requirementCfg.Hubble.Enabled).To(Equal(config.Hubble.Enabled), "requirementsConfig mismatch")
+				Expect(globalCfg.Hubble.Enabled).To(Equal(config.Hubble.Enabled), "globalConfig mismatch")
 			})
 		})
 	})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Passthrough hubble settings in NetworkConfig towards global helm values.
This ensures that the "enable-hubble" config is set to false in "cilium-config" ConfigMap if hubble is not enabled.

**Which issue(s) this PR fixes**:
Fixes #740 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Respect NetworkConfig Hubble settings in cilium-config
```
