### PR TITLE
Fix LB health checks.

### DIFF
--- a/charts/internal/cilium/charts/config/templates/configmap.yaml
+++ b/charts/internal/cilium/charts/config/templates/configmap.yaml
@@ -728,6 +728,7 @@ data:
   nat-map-stats-entries: "32"
   nat-map-stats-interval: "30s"
   enable-lb-ipam: "true"
+  default-lb-service-ipam: "none"
   enable-non-default-deny-policies: "true"
   enable-source-ip-verification: "true"
   enable-dynamic-config: "true"

--- a/pkg/charts/utils.go
+++ b/pkg/charts/utils.go
@@ -95,7 +95,7 @@ var defaultGlobalConfig = globalConfig{
 	},
 	NodePort: nodePort{
 		Enabled:                         false,
-		EnableHealthCheck:               true,
+		EnableHealthCheck:               false,
 		EnableHealthCheckLoadBalancerIP: false,
 		AutoProtectPortRange:            true,
 		BindProtection:                  false,
@@ -195,6 +195,8 @@ func generateChartValues(config *ciliumv1alpha1.NetworkConfig, network *extensio
 	if cluster.Shoot.Spec.Kubernetes.KubeProxy != nil && cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled != nil && !*cluster.Shoot.Spec.Kubernetes.KubeProxy.Enabled {
 		globalConfig.KubeProxyReplacement = true
 		globalConfig.KubeProxyReplacementHealthzBindAddr = "0.0.0.0:10256"
+		globalConfig.NodePort.EnableHealthCheck = true
+		globalConfig.NodePort.EnableHealthCheckLoadBalancerIP = true
 		globalConfig.Images[cilium.KubeProxyImageName] = imagevector.CiliumKubeProxyImage(cluster.Shoot.Spec.Kubernetes.Version)
 
 		if config != nil && config.KubeProxy != nil && config.KubeProxy.ServiceHost != nil && config.KubeProxy.ServicePort != nil {


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
* Add efault-lb-service-ipam: "none"  to prevents the new v1.19 wildcard <LB_VIP>:0/ANY [non-routable] entry that is intercepting and dropping health check traffic for infrastructures like GCP, where healthchecks have the LB address as destination.

* Only set EnableHealthCheck and EnableHealthCheckLoadBalancerIP if KubeProxy is not enabled.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue where Loadbalancer health check are dropped for some platforms (GCP) has been fixed.
```
