### PR TITLE
Update cilium-envoy to v1.36.8

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -15,13 +15,13 @@ images:
     - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
       value:
       # https://github.com/cilium/proxy: v1.19.x -> v1.36.x
-      # https://www.envoyproxy.io/docs/envoy/v1.36.6/intro/arch_overview/security/external_deps
+      # https://www.envoyproxy.io/docs/envoy/v1.36.8/intro/arch_overview/security/external_deps
       - name: 'v8'
-        version: '12.9.202.27'
+        version: '13.8.258.26'
   - name: cilium-envoy
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/cilium-envoy
-    tag: v1.36.6-1778235340-b87d1e32f522b33bd51701c6476d199326f01496
+    tag: v1.36.8-1781157951-a7f42a3390781539911b5b9107881b35ecc4e752
     labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:
@@ -34,9 +34,9 @@ images:
     - name: 'cloud.gardener.cnudie/dso/scanning-hints/package-versions'
       value:
       # https://github.com/cilium/proxy: v1.19.x -> v1.36.x
-      # https://www.envoyproxy.io/docs/envoy/v1.36.6/intro/arch_overview/security/external_deps
+      # https://www.envoyproxy.io/docs/envoy/v1.36.8/intro/arch_overview/security/external_deps
       - name: 'c-ares'
-        version: '1.21.0'
+        version: '1.34.6'
   - name: cilium-operator
     sourceRepository: github.com/cilium/cilium
     repository: quay.io/cilium/operator


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
cilium-envoy is updated to version v1.36.8 to match expected version of cilium-agent 1.19.5
```
