### PR TITLE
Don't reuse ca in hubble-generate-certs

### DIFF
--- a/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
+++ b/charts/internal/cilium/charts/hubble-relay/templates/job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   annotations:
     resources.gardener.cloud/delete-on-invalid-update: "true"
-  name: hubble-generate-certs-2
+  name: hubble-generate-certs
   namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: hubble-generate-certs
@@ -37,7 +37,6 @@ spec:
           # the values used in past runs by inspecting the completed pod.
           args:
             - "--ca-generate=true"
-            - "--ca-reuse-secret"
             - "--ca-secret-namespace=kube-system"
             - "--ca-secret-name=cilium-ca"
             - "--ca-common-name=Cilium CA"


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-networking-cilium/pull/734 accidentally reverted https://github.com/gardener/gardener-extension-networking-cilium/pull/639

We still want to renew the CA with each run.
Also revert the unintended name change.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue where the cilium CA was never renewed.
```
