### PR TITLE
agent: NET_ADMIN capability for config initContainer

### DIFF
--- a/charts/internal/cilium/charts/agent/templates/daemonset.yaml
+++ b/charts/internal/cilium/charts/agent/templates/daemonset.yaml
@@ -359,6 +359,11 @@ spec:
         - cilium-dbg
         - build-config
         securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            drop:
+            - ALL
           allowPrivilegeEscalation: false
         env:
         - name: K8S_NODE_NAME


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Add NET_ADMIN capability to config initContainer.
This was added to the config container upstream in https://github.com/cilium/cilium/commit/cf3889af46a4058d5e89495d502fc19c10713110

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We saw the cilium containers not being able to start on a ubuntu 5.15 kernel being stuck at the config initContainer:
```
2026-07-06T11:11:22.090991035Z stdout F time=2026-07-06T11:11:22.090919715Z level=error 
msg="Unable to contact k8s api-server" subsys=cilium-dbg module=k8s-client ipAddr=https://api.e2e-ynj7sv8.ondemand.internal.ond-seal.ci.ske.eu01.stackit.cloud:443 
error="Get \"https://api.e2e-ynj7sv8.ondemand.internal.ond-seal.ci.ske.eu01.stackit.cloud:443/api/v1/namespaces/kube-system\":
dial tcp: lookup api.e2e-ynj7sv8.ondemand.internal.ond-seal.ci.ske.eu01.stackit.cloud on 1.1.1.1:53: dial udp 1.1.1.1:53: operation not permitted"
```

The initContainer was not able to fetch the configuration from the API server.
`Operation not permitted` on a dial call was very new to us, so we traced into the binary with strace:
```
write(6, "\1\0\0\0\0\0\0\0", 8)         = 8
socket(AF_INET, SOCK_DGRAM|SOCK_CLOEXEC|SOCK_NONBLOCK, IPPROTO_IP) = 4
setsockopt(4, SOL_SOCKET, SO_BROADCAST, [1], 4) = 0
setsockopt(4, SOL_SOCKET, SO_MARK, "\0\v\1\0\0\0\0\0", 8) = -1 EPERM (Operation not permitted)
close(4)                                = 0
```

Cilium marks the sockets that dial towards the API server with a magic mark to filter the connections in their eBPF code to not break connections.
The NET_ADMIN capability strictly defines that this marking must be done by a process with the capability:
```
CAP_NET_ADMIN
              Perform various network-related operations:
              •  use [setsockopt(2)](https://man7.org/linux/man-pages/man2/setsockopt.2.html) to set the following socket options:
                 SO_DEBUG, SO_MARK, SO_PRIORITY (for a priority outside
                 the range 0 to 6), SO_RCVBUFFORCE, and SO_SNDBUFFORCE.
```

Interestingly enough we were not able to see this in a 6.16 flatcar kernel:
```
time=2026-07-06T13:39:16.222032327Z level=info msg="Establishing connection to apiserver" subsys=cilium-dbg module=k8s-client ipAddr=https://api.cilbuntu.ondemand.internal.ond-seal.ci.ske.eu01.stackit.cloud:443
setsockopt(7, SOL_SOCKET, SO_MARK, [68352], 8) = 0
```



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Add NET_ADMIN capability to config initContainer to support kube-apiserver host firewall bypass 
```
